### PR TITLE
Avoid purging Maven via its dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,6 @@ test-java:  ## Format code to respect CS
 		docker build -t $${DIR} --no-cache . || exit 1; \
 		echo " > Testing basic commands"; \
 		docker run --rm $${DIR} java -version || exit 1; \
+		docker run --rm $${DIR} mvn --version || exit 1; \
 	done
 	echo "done!"

--- a/java8/Dockerfile
+++ b/java8/Dockerfile
@@ -24,9 +24,9 @@ RUN echo "Starting ..." && \
 
     echo "Cleaning files!" && \
     rm -rf /tmp/* && \
-    apt-get remove --purge -y dpkg-dev fakeroot file libx11-6 libx11-data manpages manpages-dev \
-      openssl patch x11-common xauth xz-utils zlib1g-dev && \
+    apt-get remove --purge -y dpkg-dev fakeroot file manpages manpages-dev \
+      openssl patch xauth xz-utils zlib1g-dev && \
 
-    apt-get clean apt-get purge &&  rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && apt-get purge &&  rm -rf /var/lib/apt/lists/* && \
 
     echo "Done!"


### PR DESCRIPTION
`libmaven2-core-java` depends on `libdoxia-java`, which depends on `libfop-java`, which depends on `libxt6`, which depends on `libx11-6`, which shouldn't be removed.

Fixes #10 