### PR TITLE
Remove a bit less elements to keep the images functional

### DIFF
--- a/java8/Dockerfile
+++ b/java8/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "Starting ..." && \
 
     apt-get -y autoremove && \
     apt-get clean && apt-get purge && \
-    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/info /var/lib/dpkg/*-old && \
+    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
     rm -rf /var/cache/oracle-jdk8-installer && \
     rm -rf /usr/lib/jvm/java-8-oracle/*src.zip /usr/lib/jvm/java-8-oracle/lib/*javafx* \

--- a/java8/Dockerfile
+++ b/java8/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "Starting ..." && \
     echo "deb-src http://httpredir.debian.org/debian jessie main" >> /etc/apt/sources.list && \
     echo "deb-src http://httpredir.debian.org/debian jessie-updates main" >> /etc/apt/sources.list && \
     echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
-    apt-get clean && apt-get -qq update && \
+    apt-get -qq clean && apt-get -qq update && \
     apt-get -qq -y install build-essential curl git subversion make mercurial openssh-client && \
 
     echo "Done base install!" && \
@@ -18,21 +18,21 @@ RUN echo "Starting ..." && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 && \
     apt-get -qq update && \
     echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    apt-get -y install oracle-java8-installer oracle-java8-set-default maven && \
+    apt-get -qq -y install oracle-java8-installer oracle-java8-set-default maven && \
     echo "Done Java!" && \
 
     echo "Starting AWS" && \
-    apt-get install -y python-pip groff-base && \
-    pip install -U awscli && \
+    apt-get -qq -y install python-pip groff-base && \
+    pip install -q -U awscli && \
     echo "Done AWS!" && \
 
     echo "Cleaning files!" && \
     rm -rf /tmp/* && \
-    apt-get remove --purge -y dpkg-dev fakeroot file gcc-4.8-base icc-profiles-free manpages manpages-dev \
+    apt-get -qq -y remove --purge dpkg-dev fakeroot file gcc-4.8-base icc-profiles-free manpages manpages-dev \
       python-pip openssl patch xauth xz-utils zlib1g-dev && \
 
-    apt-get -y autoremove && \
-    apt-get clean && apt-get purge && \
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && apt-get -qq purge && \
     rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
     rm -rf /var/cache/oracle-jdk8-installer && \

--- a/node4.6/Dockerfile
+++ b/node4.6/Dockerfile
@@ -10,8 +10,8 @@ RUN echo "Starting ..." && \
     echo "deb-src http://httpredir.debian.org/debian jessie main" >> /etc/apt/sources.list && \
     echo "deb-src http://httpredir.debian.org/debian jessie-updates main" >> /etc/apt/sources.list && \
     echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
-    apt-get clean && apt-get -qq update && \
-    apt-get -y install build-essential libssl-dev curl git subversion make mercurial \
+    apt-get -qq clean && apt-get -qq update && \
+    apt-get -qq -y install build-essential libssl-dev curl git subversion make mercurial \
       libmcrypt-dev libreadline-dev ruby-full openssh-client ocaml libelf-dev && \
     gem install sass --verbose && \
     gem install scss_lint --verbose && \
@@ -34,19 +34,19 @@ RUN echo "Starting ..." && \
     echo "Done JS!" && \
 
     echo "Starting AWS" && \
-    apt-get install -y python-pip groff-base && \
-    pip install -U awscli && \
+    apt-get -qq -y install python-pip groff-base && \
+    pip install -q -U awscli && \
     echo "Done AWS!" && \
 
     echo "Cleaning files!" && \
     rm -rf /tmp/* && \
-    apt-get remove --purge -y emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \
+    apt-get -qq -y remove --purge emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \
       firebird2.5-server-common man-db manpages manpages-dev \
       mysql-client-5.5 mysql-common mysql-server-5.5 mysql-server-core-5.5 odbcinst odbcinst1debian2 \
       patch po-debconf psmisc python-pip xauth xtrans-dev xz-utils zlib1g-dev && \
 
-    apt-get -y autoremove && \
-    apt-get clean && apt-get purge && \
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && apt-get -qq purge && \
     rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
 

--- a/node4.6/Dockerfile
+++ b/node4.6/Dockerfile
@@ -47,7 +47,7 @@ RUN echo "Starting ..." && \
 
     apt-get -y autoremove && \
     apt-get clean && apt-get purge && \
-    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/info /var/lib/dpkg/*-old && \
+    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
 
     echo "Done!"

--- a/node6.9/Dockerfile
+++ b/node6.9/Dockerfile
@@ -10,8 +10,8 @@ RUN echo "Starting ..." && \
     echo "deb-src http://httpredir.debian.org/debian jessie main" >> /etc/apt/sources.list && \
     echo "deb-src http://httpredir.debian.org/debian jessie-updates main" >> /etc/apt/sources.list && \
     echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
-    apt-get clean && apt-get -qq update && \
-    apt-get -y install build-essential libssl-dev curl git subversion make mercurial \
+    apt-get -qq clean && apt-get -qq update && \
+    apt-get -qq -y install build-essential libssl-dev curl git subversion make mercurial \
       libmcrypt-dev libreadline-dev ruby-full openssh-client ocaml libelf-dev && \
     gem install sass --verbose && \
     gem install scss_lint --verbose && \
@@ -34,19 +34,19 @@ RUN echo "Starting ..." && \
     echo "Done JS!" && \
 
     echo "Starting AWS" && \
-    apt-get install -y python-pip groff-base && \
-    pip install -U awscli && \
+    apt-get -qq -y install python-pip groff-base && \
+    pip install -q -U awscli && \
     echo "Done AWS!" && \
 
     echo "Cleaning files!" && \
     rm -rf /tmp/* && \
-    apt-get remove --purge -y emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \
+    apt-get -qq -y remove --purge emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \
       firebird2.5-server-common man-db manpages manpages-dev \
       mysql-client-5.5 mysql-common mysql-server-5.5 mysql-server-core-5.5 odbcinst odbcinst1debian2 \
       patch po-debconf psmisc python-pip xauth xtrans-dev xz-utils zlib1g-dev && \
 
-    apt-get -y autoremove && \
-    apt-get clean && apt-get purge && \
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && apt-get -qq purge && \
     rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
 

--- a/node6.9/Dockerfile
+++ b/node6.9/Dockerfile
@@ -47,7 +47,7 @@ RUN echo "Starting ..." && \
 
     apt-get -y autoremove && \
     apt-get clean && apt-get purge && \
-    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/info /var/lib/dpkg/*-old && \
+    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
 
     echo "Done!"

--- a/node7.0/Dockerfile
+++ b/node7.0/Dockerfile
@@ -48,7 +48,7 @@ RUN echo "Starting ..." && \
 
     apt-get -y autoremove && \
     apt-get clean && apt-get purge && \
-    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/info /var/lib/dpkg/*-old && \
+    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
 
     echo "Done!"

--- a/node7.0/Dockerfile
+++ b/node7.0/Dockerfile
@@ -10,8 +10,8 @@ RUN echo "Starting ..." && \
     echo "deb-src http://httpredir.debian.org/debian jessie main" >> /etc/apt/sources.list && \
     echo "deb-src http://httpredir.debian.org/debian jessie-updates main" >> /etc/apt/sources.list && \
     echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
-    apt-get clean && apt-get -qq update && \
-    apt-get -y install build-essential libssl-dev curl git subversion make mercurial \
+    apt-get -qq clean && apt-get -qq update && \
+    apt-get -qq -y install build-essential libssl-dev curl git subversion make mercurial \
       libmcrypt-dev libreadline-dev ruby-full openssh-client ocaml libelf-dev && \
 
     gem install sass --verbose && \
@@ -35,19 +35,19 @@ RUN echo "Starting ..." && \
     echo "Done JS!" && \
 
     echo "Starting AWS" && \
-    apt-get install -y python-pip groff-base && \
-    pip install -U awscli && \
+    apt-get -qq -y install python-pip groff-base && \
+    pip install -q -U awscli && \
     echo "Done AWS!" && \
 
     echo "Cleaning files!" && \
     rm -rf /tmp/* && \
-    apt-get remove --purge -y emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \
+    apt-get -qq -y remove --purge emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \
       firebird2.5-server-common man-db manpages manpages-dev \
       mysql-client-5.5 mysql-common mysql-server-5.5 mysql-server-core-5.5 odbcinst odbcinst1debian2 \
       patch po-debconf psmisc python-pip xauth xtrans-dev xz-utils zlib1g-dev && \
 
-    apt-get -y autoremove && \
-    apt-get clean && apt-get purge && \
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && apt-get -qq purge && \
     rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
 

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "Starting ..." && \
 
     apt-get -y autoremove && \
     apt-get clean && apt-get purge && \
-    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/info /var/lib/dpkg/*-old && \
+    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
 
     echo "Done!"

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -13,14 +13,14 @@ RUN echo "Starting ..." && \
     echo "deb-src http://httpredir.debian.org/debian jessie main" >> /etc/apt/sources.list && \
     echo "deb-src http://httpredir.debian.org/debian jessie-updates main" >> /etc/apt/sources.list && \
     echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
-    apt-get clean && apt-get -qq update && \
-    apt-get -y install build-essential libssl-dev curl git subversion make mercurial \
+    apt-get -qq clean && apt-get -qq update && \
+    apt-get -qq -y install build-essential libssl-dev curl git subversion make mercurial \
       libmcrypt-dev libreadline-dev openssh-client && \
 
     echo "Done base install!" && \
 
     echo "Starting PHP" && \
-    apt-get -y build-dep php5-cli && \
+    apt-get -qq -y build-dep php5-cli && \
     cd /root && git clone https://github.com/CHH/phpenv.git && cd phpenv && ./bin/phpenv-install.sh  && \
     cd /root && git clone git://github.com/php-build/php-build && cd php-build && ./install.sh && \
     php-build -i development ${PHP_VERSION} "/root/.phpenv/versions/${PHP_VERSION}" && \
@@ -36,20 +36,20 @@ RUN echo "Starting ..." && \
     echo "Done PHP!" && \
 
     echo "Starting AWS" && \
-    apt-get install -y python-pip groff-base && \
-    pip install -U awscli && \
+    apt-get -qq -y install python-pip groff-base && \
+    pip install -q -U awscli && \
     echo "Done AWS!" && \
 
     echo "Cleaning files!" && \
     rm -rf /tmp/* && \
-    apt-get remove --purge -y dpkg-dev emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \
+    apt-get -qq -y remove --purge dpkg-dev emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \
       firebird2.5-server-common libx11-6 libx11-data libx11-dev man-db manpages manpages-dev \
       mysql-client-5.5 mysql-common mysql-server-5.5 mysql-server-core-5.5 odbcinst odbcinst1debian2 \
       openssl patch po-debconf psmisc python-pip x11-common x11proto-core-dev \
       x11proto-input-dev x11proto-kb-dev xauth xorg-sgml-doctools xtrans-dev xz-utils zlib1g-dev && \
 
-    apt-get -y autoremove && \
-    apt-get clean && apt-get purge && \
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && apt-get -qq purge && \
     rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
 

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -20,7 +20,7 @@ RUN echo "Starting ..." && \
     echo "Done base install!" && \
 
     echo "Starting PHP" && \
-    apt-get -qq -y build-dep php5-cli && \
+    apt-get -qq -y build-dep php5-cli postgresql-client && \
     cd /root && git clone https://github.com/CHH/phpenv.git && cd phpenv && ./bin/phpenv-install.sh  && \
     cd /root && git clone git://github.com/php-build/php-build && cd php-build && ./install.sh && \
     php-build -i development ${PHP_VERSION} "/root/.phpenv/versions/${PHP_VERSION}" && \

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "Starting ..." && \
 
     apt-get -y autoremove && \
     apt-get clean && apt-get purge && \
-    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/info /var/lib/dpkg/*-old && \
+    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
 
     echo "Done!"

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -13,14 +13,14 @@ RUN echo "Starting ..." && \
     echo "deb-src http://httpredir.debian.org/debian jessie main" >> /etc/apt/sources.list && \
     echo "deb-src http://httpredir.debian.org/debian jessie-updates main" >> /etc/apt/sources.list && \
     echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
-    apt-get clean && apt-get -qq update && \
-    apt-get -y install build-essential libssl-dev curl git subversion make mercurial \
+    apt-get -qq clean && apt-get -qq update && \
+    apt-get -qq -y install build-essential libssl-dev curl git subversion make mercurial \
       libmcrypt-dev libreadline-dev openssh-client && \
 
     echo "Done base install!" && \
 
     echo "Starting PHP" && \
-    apt-get -y build-dep php5-cli && \
+    apt-get -qq -y build-dep php5-cli && \
     cd /root && git clone https://github.com/CHH/phpenv.git && cd phpenv && ./bin/phpenv-install.sh  && \
     cd /root && git clone git://github.com/php-build/php-build && cd php-build && ./install.sh && \
     php-build -i development ${PHP_VERSION} "/root/.phpenv/versions/${PHP_VERSION}" && \
@@ -36,20 +36,20 @@ RUN echo "Starting ..." && \
     echo "Done PHP!" && \
 
     echo "Starting AWS" && \
-    apt-get install -y python-pip groff-base && \
+    apt-get -qq -y install python-pip groff-base && \
     pip install -U awscli && \
     echo "Done AWS!" && \
 
     echo "Cleaning files!" && \
     rm -rf /tmp/* && \
-    apt-get remove --purge -y dpkg-dev emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \
+    apt-get -qq -y remove --purge dpkg-dev emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \
       firebird2.5-server-common libx11-6 libx11-data libx11-dev man-db manpages manpages-dev \
       mysql-client-5.5 mysql-common mysql-server-5.5 mysql-server-core-5.5 odbcinst odbcinst1debian2 \
       openssl patch po-debconf psmisc python-pip x11-common x11proto-core-dev \
       x11proto-input-dev x11proto-kb-dev xauth xorg-sgml-doctools xtrans-dev xz-utils zlib1g-dev && \
 
-    apt-get -y autoremove && \
-    apt-get clean && apt-get purge && \
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && apt-get -qq purge && \
     rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
 

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -20,7 +20,7 @@ RUN echo "Starting ..." && \
     echo "Done base install!" && \
 
     echo "Starting PHP" && \
-    apt-get -qq -y build-dep php5-cli && \
+    apt-get -qq -y build-dep php5-cli postgresql-client && \
     cd /root && git clone https://github.com/CHH/phpenv.git && cd phpenv && ./bin/phpenv-install.sh  && \
     cd /root && git clone git://github.com/php-build/php-build && cd php-build && ./install.sh && \
     php-build -i development ${PHP_VERSION} "/root/.phpenv/versions/${PHP_VERSION}" && \


### PR DESCRIPTION
Removing `/var/lib/dpkg/info` prevents `dpkg` and APT from functioning correctly.

Also, `composer` in the PHP images depends on the PostgreSQL lib (`libpq5`) but not as a deb dependency, so in order to keep the `apt-get autoremove` step, the `postgresql-client` is installed.