### PR TITLE
Set up a locale with a UTF-8 encoding

### DIFF
--- a/java8/Dockerfile
+++ b/java8/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:8.6
 MAINTAINER Stephane Leclercq <leclercq@ekino.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
 
 RUN echo "Starting ..." && \
     echo "deb-src http://httpredir.debian.org/debian jessie main" >> /etc/apt/sources.list && \

--- a/node4.6/Dockerfile
+++ b/node4.6/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:8.6
 MAINTAINER Thomas Rabaix <rabaix@ekino.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
 ENV NVM_DIR /root/.nvm
 ENV PATH /root/.nvm/versions/node/current/bin:usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV NODE_VERSION 4.6.2

--- a/node6.9/Dockerfile
+++ b/node6.9/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:8.6
 MAINTAINER Thomas Rabaix <rabaix@ekino.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
 ENV NVM_DIR /root/.nvm
 ENV PATH /root/.nvm/versions/node/current/bin:usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV NODE_VERSION 6.9.1

--- a/node7.0/Dockerfile
+++ b/node7.0/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:8.6
 MAINTAINER Thomas Rabaix <rabaix@ekino.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
 ENV NVM_DIR /root/.nvm
 ENV PATH /root/.nvm/versions/node/current/bin:usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV NODE_VERSION 7.0.0

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:8.6
 MAINTAINER Thomas Rabaix <rabaix@ekino.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
 ENV PHP_BUILD_EXTRA_MAKE_ARGUMENTS -j4
 ENV COMPOSER_NO_INTERACTION 1
 ENV PATH /root/.phpenv/versions/current/bin:usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:8.6
 MAINTAINER Thomas Rabaix <rabaix@ekino.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
 ENV PHP_BUILD_EXTRA_MAKE_ARGUMENTS -j4
 ENV COMPOSER_NO_INTERACTION 1
 ENV PATH /root/.phpenv/versions/current/bin:usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
The JVM at least uses the encoding of the current locale, or an ANSI
encoding if none is set, which can give ugly results when displaying
non-ANSI characters.