### PR TITLE
Add gcc and g++ into Node image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versions
 * Upgrade composer version: 1.4.2
 * Upgrade the base Debian image: 8.7
 * Upgrade Java version: 8u131
-* Add imagemagick into Node image
+* Add imagemagick, gcc and g++ into Node image
 * Add a new Ruby image
 * Add composer hirak/prestissimo plugin
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "Starting ..." && \
     echo "deb-src http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
     apt-get -qq clean && apt-get -qq update && \
     apt-get -qq -y install build-essential libssl-dev curl git imagemagick subversion make mercurial \
-      libmcrypt-dev libreadline-dev ruby-full openssh-client ocaml libelf-dev bzip2 && \
+      libmcrypt-dev libreadline-dev ruby-full openssh-client ocaml libelf-dev bzip2 gcc g++ && \
     gem install sass --verbose && \
     gem install scss_lint --verbose && \
 


### PR DESCRIPTION
gcc and g++ are needed by some node dependencies. Having to install them manually on each build creates false negatives because of network issues and is generally inefficient.
