### PR TITLE
fix(dind-aws): update base image to use dockerd instead of docker daemon

### DIFF
--- a/dind-aws/Dockerfile
+++ b/dind-aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM gitlab/dind
+FROM jpetazzo/dind
 MAINTAINER Hugo Briand <briand@ekino.com>
 
 ARG CI_HELPER_VERSION


### PR DESCRIPTION
`gitlab/dind` was built a year ago and is outdated