### PR TITLE
Prevent Yarn from installing Node.js

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -44,7 +44,7 @@ RUN echo "Starting ..." && \
 
     curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb http://dl.yarnpkg.com/debian/ stable main" >> /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && apt-get install yarn && \
+    apt-get update && apt-get install yarn --no-install-recommends && \
 
     echo "Done JS!" && \
 


### PR DESCRIPTION
Yarn automatically installs Node.js by default.

We can skip it by using `--no-install-recommends` as recommended by the [documentation](https://yarnpkg.com/lang/en/docs/install/) : 

> If using nvm you can avoid the node installation by doing:
 `sudo apt-get install --no-install-recommends yarn`