### PR TITLE
Add an up to date mime types definition file for the images that use AWS CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versions
 * Remove Maven and Gradle from React Native image
 * Add bash to Python images
 * Add an up to date mime types definition file for the images that use AWS CLI
+* Install PEAR in the PHP 5.3 image
 
 2018-06-14
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions
 * Use openjdk slim as base React Native image
 * Remove Maven and Gradle from React Native image
 * Add bash to Python images
+* Add an up to date mime types definition file for the images that use AWS CLI
 
 2018-06-14
 ----------

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Please review the [CHANGELOG.md](CHANGELOG.md) file for versions per tag.
 
 Each box is tested and built using TravisCI.
 
-The ``travis.py`` script try to be clever:
+The `travis.py` script try to be clever:
  - PR: only images with modified files are built.
- - Merge to master: only images with modified files are built and pushed to the docker registry with the tag ``latest-IMAGE``
+ - Merge to master: only images with modified files are built and pushed to the docker registry with the tag `latest-IMAGE`
  - TAG: all images are built and pushed to the docker registry
- - Nightly: all images are built and pushed to the docker registry with the tag ``nightly-IMAGE``
+ - Nightly: all images are built and pushed to the docker registry with the tag `nightly-IMAGE`
 
 [![Build Status](https://travis-ci.org/ekino/docker-buildbox.svg?branch=master)](https://travis-ci.org/ekino/docker-buildbox)
 

--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -12,4 +12,7 @@ RUN echo "Install AWS" && \
     echo "Install CI Helper" && \
     curl -sSL https://github.com/rande/gitlab-ci-helper/releases/download/${CI_HELPER_VERSION}/alpine-amd64-gitlab-ci-helper -o /usr/bin/ci-helper && \
     chmod 755 /usr/bin/ci-helper && \
-    echo "Done install CI Helper"
+    echo "Done install CI Helper" && \
+
+    echo "Adding an up to date mime-types definition file" && \
+    curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types

--- a/dind-aws/Dockerfile
+++ b/dind-aws/Dockerfile
@@ -25,6 +25,9 @@ RUN echo "Install AWS" && \
     chmod +x /usr/local/bin/docker-compose && \
     docker-compose --version && \
 
+    echo "Adding an up to date mime-types definition file" && \
+    curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types && \
+
     echo "Cleaning files!" && \
     rm -rf /tmp/* /var/cache/apk/* && \
 

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -36,4 +36,7 @@ RUN echo "Starting...\n" && \
     chmod 755 /usr/bin/modd && \
     echo "Successfully installed Modd\n" && \
 
+    echo "Adding an up to date mime-types definition file" && \
+    curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types && \
+
     echo "Done!"

--- a/java/Dockerfile.tpl
+++ b/java/Dockerfile.tpl
@@ -44,6 +44,9 @@ RUN echo "Starting ..." && \
     apt-get -qq -y install maven && \
     echo "Done Install Maven!" && \
 
+    echo "Adding an up to date mime-types definition file" && \
+    curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types && \
+
     echo "Cleaning files!" && \
     rm -rf /tmp/* && \
     apt-get -y remove --purge \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -53,6 +53,9 @@ RUN echo "Starting ..." && \
     pip install -q -U awscli && \
     echo "Done AWS!" && \
 
+    echo "Adding an up to date mime-types definition file" && \
+    curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types && \
+
     echo "Cleaning files!" && \
     rm -rf /tmp/* && \
     apt-get -qq -y remove --purge emacsen-common fakeroot file firebird2.5-common firebird2.5-common-doc \

--- a/php/5.3/Dockerfile
+++ b/php/5.3/Dockerfile
@@ -28,7 +28,6 @@ RUN echo "Starting ..." && \
     phpenv rehash && \
     curl -sSL https://pear.php.net/go-pear.phar -o /tmp/go-pear.phar && \
     php /tmp/go-pear.phar && \
-    rm /tmp/go-pear.phar && \
     pear config-set php_ini $(php -r 'echo php_ini_loaded_file();') && \
 
     ln -s /home/.phpenv/versions/${PHP_VERSION} /home/.phpenv/versions/current && \

--- a/php/5.3/Dockerfile
+++ b/php/5.3/Dockerfile
@@ -26,6 +26,9 @@ RUN echo "Starting ..." && \
     MAKEFLAGS=' -j8' LDFLAGS=-lstdc++ phpenv install ${PHP_VERSION} && \
     phpenv global ${PHP_VERSION} && \
     phpenv rehash && \
+    curl -sSL http://pear.php.net/go-pear.phar -o /tmp/go-pear.phar && \
+    php /tmp/go-pear.phar && \
+    rm /tmp/go-pear.phar && \
     pear config-set php_ini $(php -r 'echo php_ini_loaded_file();') && \
 
     ln -s /home/.phpenv/versions/${PHP_VERSION} /home/.phpenv/versions/current && \

--- a/php/5.3/Dockerfile
+++ b/php/5.3/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Starting ..." && \
     MAKEFLAGS=' -j8' LDFLAGS=-lstdc++ phpenv install ${PHP_VERSION} && \
     phpenv global ${PHP_VERSION} && \
     phpenv rehash && \
-    curl -sSL http://pear.php.net/go-pear.phar -o /tmp/go-pear.phar && \
+    curl -sSL https://pear.php.net/go-pear.phar -o /tmp/go-pear.phar && \
     php /tmp/go-pear.phar && \
     rm /tmp/go-pear.phar && \
     pear config-set php_ini $(php -r 'echo php_ini_loaded_file();') && \

--- a/php/Dockerfile.tpl
+++ b/php/Dockerfile.tpl
@@ -75,6 +75,9 @@ zend_extension=opcache.so \n\
     pip install -q -U awscli && \
     echo "Done AWS!" && \
 
+    echo "Adding an up to date mime-types definition file" && \
+    curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types && \
+
     echo "Cleaning files!" && \
     apk del --purge alpine-sdk autoconf && \
     rm -rf /tmp/* /usr/share/doc /var/cache/apk/* && \

--- a/react-native/Dockerfile
+++ b/react-native/Dockerfile
@@ -142,6 +142,13 @@ RUN npm install rnpm -g
 RUN npm install -g yarn
 
 # ——————————
+# Mime types
+# ——————————
+USER root
+RUN echo "Adding an up to date mime-types definition file" && \
+    curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types
+
+# ——————————
 # Clean files
 # ——————————
 USER root


### PR DESCRIPTION
The mime type of the files that are pushed in an AWS storage (and the `Content-Type` HTTP header sent for them) is defined by the [AWS CLI](https://github.com/aws/aws-cli) tool.

You can see [there](https://github.com/aws/aws-cli/blob/5d349108c974d80b5b1a634e8a7433556a31e605/awscli/customizations/s3/utils.py#L294) that the AWS CLI uses the [mimetypes](https://docs.python.org/2/library/mimetypes.html) core Python module to guess the mime types, based on the sender `/etc/mime.types` file.

As the buildboxes use Debian as their base OS, the provider of that file is the [mime-support](https://salsa.debian.org/debian/mime-support) Debian package. But in the current stable Debian version, the more up to date version of the package is 3.60, and the definition file is incomplete (eg: the woff2 mime type is missing).

So, in order to update the definition file and to prevent further missing mime types, I propose to always fetch the last `master` version of the mime-support Debian package.