### PR TITLE
feat(sonarts): add sonarts image containing node, npm, sonar-scanner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - env: LANGUAGE=python        VERSION=3.6  PYTHON_VERSION=3.6.5
     - env: LANGUAGE=react-native  VERSION=1
     - env: LANGUAGE=ruby          VERSION=2.5
-    - env: LANGUAGE=sonar         VERSION=3.2  GLIBC_VERSION=2.23-r3 SONARSCANNER_VERSION=3.2.0.1227
+    - env: LANGUAGE=sonar         VERSION=10.7 NODE_VERSION=10.7.0-alpine GLIBC_VERSION=2.23-r3 SONARSCANNER_VERSION=3.2.0.1227
 
 script:
     - travis_wait python travis.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versions
 * Add bash to Python images
 * Add an up to date mime types definition file for the images that use AWS CLI
 * Install PEAR in the PHP 5.3 image
-* Update Alpine Version for sonar image: 3.8
+* Replace source image for sonar
 
 2018-06-14
 ----------

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Contains Ansible, CI Helper and Python 2.7
 
 ### SonarQube Scanner
 
-Contains SonarQube Scanner and CI Helper
+Contains Node, SonarQube Scanner and CI Helper
 
 ### React Native Android
 

--- a/sonar/Dockerfile.tpl
+++ b/sonar/Dockerfile.tpl
@@ -1,16 +1,15 @@
-FROM alpine:3.8
-LABEL maintainer="Thomas Rabaix <rabaix@ekino.com>"
+FROM node:{{NODE_VERSION}}
+LABEL maintainer="Sebastien Augereau <sebastien.augereau@ekino.com>"
 
+ARG CI_HELPER_VERSION
 ARG SONARSCANNER_VERSION
+ARG GLIBC_VERSION
 
 ENV PATH=/sonar-scanner/bin:/sonar-scanner/jre/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-ARG CI_HELPER_VERSION
-ARG GLIBC_VERSION
-ARG SONARSCANNER_VERSION
-
 RUN echo "Starting ..." && \
-    apk --update upgrade && apk add curl make tzdata unzip && \
+    apk --update upgrade && apk add --no-cache curl unzip  && \
+
     echo "Done base install!" && \
 
     echo "Starting Sonar Scanner" && \

--- a/travis.py
+++ b/travis.py
@@ -175,7 +175,11 @@ def run_build(buildInfo):
             build_args = "%s --build-arg MODD_VERSION=%s" % (build_args, buildInfo.modd)
 
         if language == "sonar":
-            build_args = "%s --build-arg GLIBC_VERSION=%s --build-arg SONARSCANNER_VERSION=%s" % (build_args, os.environ.get("GLIBC_VERSION"), os.environ.get("SONARSCANNER_VERSION"))
+            build_args = "%s --build-arg GLIBC_VERSION=%s --build-arg SONARSCANNER_VERSION=%s " % (build_args, os.environ.get("GLIBC_VERSION"), os.environ.get("SONARSCANNER_VERSION"))
+            build_context = "-f %s/Dockerfile.%s %s" % (language, version, language)
+            run_command_exit('sed -e "s,{{NODE_VERSION}},%s," %s/Dockerfile.tpl > %s/Dockerfile.%s' % (os.environ.get("NODE_VERSION"), language, language, version), "fail to create Dockerfile for %s %s" % (language, os.environ.get("VERSION")))
+
+
 
         cmd = "docker build -t %s %s --no-cache %s" % (image, build_args, build_context)
 
@@ -255,7 +259,8 @@ def run_build(buildInfo):
         if language == "sonar":
             print "> Testing Sonar Scanner Image..."
             run_command_exit("docker run %s %s java -version" % (run_args, image),   "Error with java version")
-            run_command_exit("docker run %s %s sonar-scanner -v" % (run_args, image), "Error with ansible-playbook check")
+            run_command_exit("docker run %s %s node --version" % (run_args, image), "Error with node check")
+            run_command_exit("docker run %s %s sonar-scanner -v" % (run_args, image), "Error with sonar-scanner check")
 
         print ""
         print "You can now test the image with the following command:\n   $ docker run --rm -ti %s" % image


### PR DESCRIPTION
Since release of official sonarTs plugin, sonar-scanner need the existence of node during run.
This is not needed for previous versions of sonarTS (https://github.com/pablissimo/SonarTsPlugin).
This new image is based upon the Dockerfile of the node buildbox with the adding of sonar-scanner.