### PR TITLE
feat(java) add new buildbox using Sun JDK 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - env: LANGUAGE=aws           VERSION=1
     - env: LANGUAGE=dind-aws      VERSION=1    DOCKER_COMPOSE_VERSION=1.21.2 GLIBC_VERSION=2.23-r3
     - env: LANGUAGE=golang        VERSION=1.9  GLIDE_VERSION=v0.13.1
+    - env: LANGUAGE=java          VERSION=6
     - env: LANGUAGE=java          VERSION=8    JAVA_VERSION=8u171-jdk-slim
     - env: LANGUAGE=java          VERSION=10   JAVA_VERSION=10.0.1-jdk-slim
     - env: LANGUAGE=node          VERSION=6.14 NODE_VERSION=6.14.3 NPM_VERSION=3.10.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versions
 * Add Blackfire probe & client in PHP images
 * Use openjdk slim as base Java image
 * Add Java version 10.0.1
+* Add Java version 6 (with only JDK and Maven 3.2.1)
 * Use openjdk slim as base React Native image
 * Remove Maven and Gradle from React Native image
 * Add bash to Python images

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Based upon official Golang image, contains glide, gin, AWS Cli and CI Helper.
 
 ### Java
 
-Contains AWS Cli, CI Helper, and Java 8.
+Contains AWS Cli, CI Helper, and Java.
+**Please note that for Java 6, the image doesn't contain CI Helper, Modd and AWS Cli.**
 
 ### Node
 

--- a/java/6/Dockerfile
+++ b/java/6/Dockerfile
@@ -1,0 +1,47 @@
+FROM debian:squeeze
+MAINTAINER Jean-Baptiste Hembise <jean-baptiste.hembise@ekino.com>
+
+RUN echo "Starting ..." && \
+
+    echo "Updating packages using sources :" && \
+    rm /etc/apt/sources.list  && \
+    echo "deb http://archive.debian.org/debian squeeze main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian squeeze-lts main contrib non-free" >> /etc/apt/sources.list && \
+    cat /etc/apt/sources.list && \
+    echo "Acquire::Check-Valid-Until false;" >> /etc/apt/apt.conf.d/02CheckValid && \
+    apt-get -qq clean -qq && apt-get -qq update && \
+
+    echo "Install base" && \
+    apt-get -qq -y --force-yes install \
+		build-essential \
+		curl \
+		git \
+		subversion \
+		make \
+		mercurial \
+		openssh-client && \
+    echo "Done Install base!" && \
+
+    echo "Install java" && \
+    echo debconf shared/accepted-sun-dlj-v1-1 boolean true | debconf-set-selections &&\
+    apt-get -y --force-yes install sun-java6-jdk && \
+    java -version && \
+    echo "Done Install java" && \
+
+    echo "Install Maven" && \
+    curl -sSL https://archive.apache.org/dist/maven/maven-3/3.2.1/binaries/apache-maven-3.2.1-bin.tar.gz | tar -xzf - -C /usr/bin && \
+    chmod 755 /usr/bin/apache-maven-3.2.1 && \
+    ln -s /usr/bin/apache-maven-3.2.1/bin/mvn /usr/bin/mvn && \
+    echo "Done Install Maven!" && \
+
+    echo "Adding an up to date mime-types definition file" && \
+    curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types && \
+
+    echo "Cleaning files!" && \
+    rm -rf /tmp/* && \
+    apt-get -qq -y autoremove && \
+    apt-get -qq clean && apt-get -qq purge && \
+    rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
+    rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB && \
+
+    echo "Done!"


### PR DESCRIPTION
Creating a new buildbox to compile old code in Java 6, using a JDK from Sun / Oracle.

A Sun JDK 6 was found on old Debian distro : squeeze (6.0). 

Unfortunatly, this distro use an old version of openssl (0.98) which prevents using "curl" over HTTPS in most cases.