### PR TITLE
Python Images - Add basic packages to build C Python dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Versions
 ========
 
-2018-07-DEV
+2018-08-DEV
 -----------
 
 * Upgrade ci-helper: 0.0.6
@@ -15,6 +15,8 @@ Versions
 * Add an up to date mime types definition file for the images that use AWS CLI
 * Install PEAR in the PHP 5.3 image
 * Update Alpine Version for sonar image: 3.8
+* Add `build-base`, `libffi-dev` and `openldap-dev` packages in Python images
+* Upgrade Pip version in Python images
 
 2018-06-14
 ----------

--- a/python/Dockerfile.tpl
+++ b/python/Dockerfile.tpl
@@ -3,14 +3,12 @@ FROM python:{{PYTHON_VERSION}}-alpine3.7
 ARG CI_HELPER_VERSION
 
 RUN echo "Starting ..." && \
-    apk add --update -q --no-cache bash curl git make openssh-client rsync tzdata && \
+    apk add --update -q --no-cache bash build-base curl git libffi-dev make openldap-dev openssh-client rsync tzdata && \
     echo "Done base install!" && \
-
     echo "Install CI Helper" && \
     curl -sSL https://github.com/rande/gitlab-ci-helper/releases/download/${CI_HELPER_VERSION}/alpine-amd64-gitlab-ci-helper -o /usr/bin/ci-helper && \
     chmod 755 /usr/bin/ci-helper && \
     echo "Done install CI Helper" && \
-
     echo "Install basics Python tools" && \
-    pip install pipenv && \
+    pip install --upgrade pipenv && \
     echo "Done install CI Helper"


### PR DESCRIPTION
* Add `basic-build`, `libffi-dev` and `openldap-dev` packages as they are often needed to build dependencies
* Upgrade pip version