### PR TITLE
fix(java) : fix aws error ImportError: No module named six

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versions
 * Upgrade Pip version in Python images
 * Update dind-aws to use 18.06.1-ce-dind
 * Fix ansible build (move from python 2.7.14-r0 to 2.7.15-r0)
+* Java image : fix aws failed when removing pip
 
 2018-06-14
 ----------

--- a/java/Dockerfile.tpl
+++ b/java/Dockerfile.tpl
@@ -55,7 +55,6 @@ RUN echo "Starting ..." && \
         file \
         manpages \
         manpages-dev \
-        python-pip \
         patch \
         xauth \
         xz-utils && \

--- a/travis.py
+++ b/travis.py
@@ -219,6 +219,7 @@ def run_build(buildInfo):
             run_command_exit("docker run %s %s java -version" % (run_args, image), "Error with java check")
             run_command_exit("docker run %s %s mvn --version" % (run_args, image), "Error with mvn check")
             if version != "6":
+                run_command_exit("docker run %s %s aws --version" % (run_args, image), "Error with mvn check")
                 run_command_exit("docker run %s %s modd --version" % (run_args, image), "Error with modd check")
 
         if language == "node":


### PR DESCRIPTION
Currently aws command return this error :
`Traceback (most recent call last):
  File "/usr/local/bin/aws", line 19, in <module>
    import awscli.clidriver
  File "/usr/local/lib/python2.7/dist-packages/awscli/clidriver.py", line 17, in <module>
    import botocore.session
  File "/usr/local/lib/python2.7/dist-packages/botocore/session.py", line 27, in <module>
    import botocore.credentials
  File "/usr/local/lib/python2.7/dist-packages/botocore/credentials.py", line 27, in <module>
    from dateutil.parser import parse
  File "/usr/local/lib/python2.7/dist-packages/dateutil/parser/__init__.py", line 2, in <module>
    from ._parser import parse, parser, parserinfo
  File "/usr/local/lib/python2.7/dist-packages/dateutil/parser/_parser.py", line 42, in <module>
    import six
ImportError: No module named six`

I remove the pip cleanup to fix that, seems that six lib is removed when you clean