### PR TITLE
fix(java): downgrade maven version for java 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - env: LANGUAGE=aws          VERSION=1        PIP_VERSION=18.1 PIPENV_VERSION=2018.10.13
     - env: LANGUAGE=dind-aws     VERSION=1        DOCKER_COMPOSE_VERSION=1.22.0 GLIBC_VERSION=2.27-r0 PIP_VERSION=18.1 PIPENV_VERSION=2018.10.13
     - env: LANGUAGE=golang       VERSION=1.9      GLIDE_VERSION=v0.13.1
-    - env: LANGUAGE=java         VERSION=6        MAVEN_VERSION=3.2.5
+    - env: LANGUAGE=java         VERSION=6        MAVEN_VERSION=3.2.1
     - env: LANGUAGE=java         VERSION=8        JAVA_VERSION=8u181-jdk-slim
     - env: LANGUAGE=java         VERSION=10       JAVA_VERSION=10.0.2-jdk-slim
     - env: LANGUAGE=java         VERSION=11       JAVA_VERSION=11.0.1-jdk-slim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Versions
 ----------
 
 * Upgrade Java versions: 8u181, 10.0.2, 11.0.1
+* Downgrade Maven version to 3.2.1 for Java 6 buildbox (Maven 3.2.3+ uses HTTPS by default)
 
 2018-10-29
 ----------


### PR DESCRIPTION
We encounter a problem using Maven 3.2.5 with old Linux distro (the one for Java 6 buildbox), as it uses HTTPS by default to connect to Maven Central. This one requires a recent version of TLS protocol, not present in the old Linux distro : that strikes errors like the one below.

```
Downloading: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/maven-metadata.xml
[WARNING] Could not transfer metadata org.apache.maven.plugins:maven-compiler-plugin/maven-metadata.xml from/to central (https://repo.maven.apache.org/maven2): Received fatal alert: protocol_version
```