### PR TITLE
chore(java): fix java 8/11 images build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versions
 * Upgrade Composer version: 1.8.5
 * Upgrade Xdebug version: 2.7.2
 * Upgrade Ruby version: 2.6.3
+* Fix Java 8/11 image issues from debian:stretch-slim
 
 2019-04-05
 ----------

--- a/java/Dockerfile.tpl
+++ b/java/Dockerfile.tpl
@@ -12,6 +12,11 @@ RUN echo "Starting ..." && \
 
     echo "Updating packages using sources :" && \
     cat /etc/apt/sources.list && \
+
+    if [ ! -d /usr/share/man/man1 ]; then \
+        mkdir -p /usr/share/man/man1; \
+    fi; \
+
     apt-get -qq clean -qq && apt-get -qq update && \
 
     echo "Install base" && \


### PR DESCRIPTION
Error on build : 
```
Setting up openjdk-8-jre-headless:amd64 (8u212-b03-2~deb9u1) ...
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/rmid to provide /usr/bin/rmid (rmid) in auto mode
update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
dpkg: error processing package openjdk-8-jre-headless:amd64 (--configure):


```
Looks like this issue on debian stretch : https://github.com/debuerreotype/docker-debian-artifacts/issues/24

As described in the issue openjdk has previously had a fix for this, but it seems not reported on latest dockerfile ... I just copy/paste the fix in our image.
This is a quick fix, maybe in a next release we can move to adoptopenjdk sources that seems more stable ...
