### PR TITLE
Fix ansible 2.5.5 w/ python 2.7 image build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 matrix:
   include:
-    - env: LANGUAGE=ansible      VERSION=2.5.5-r0 PYTHON_VERSION=2.7.15-r1
+    - env: LANGUAGE=ansible      VERSION=2.5.5
     - env: LANGUAGE=arachni      VERSION=1.5      ARACHNI_VERSION=1.5.1 ARACHNI_WEB_UI_VERSION=0.5.12
     - env: LANGUAGE=chrome       VERSION=1
     - env: LANGUAGE=aws          VERSION=1.1      PIP_VERSION=19.1.1 PIPENV_VERSION=2018.11.26 PY_YAML_VERSION=3.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versions
 * Add new dockerfile "terraform" version 0.12.0
 * Fix Golang version for accurate image tag
 * Add a new image integrating NCC Scoutsuite
+* Change Ansible base image for python:2.7-alpine3.8
 
 2019-04-05
 ----------

--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.8
+FROM python:2.7-alpine3.8
 
-ARG CI_HELPER_VERSION
-ARG PYTHON_VERSION
 ARG VERSION
+ARG CI_HELPER_VERSION
 
 WORKDIR /root
 RUN echo "Install Ansible with deps" && \
-    apk --update --no-cache add bash ca-certificates curl git openssh-client python=${PYTHON_VERSION} py-pip ansible=${VERSION} && \
-    echo "Done install Ansible with deps" &&\
+    apk add --update -q --no-cache bash build-base curl git libffi-dev make openssh-client rsync tzdata openssl-dev && \
+    pip install ansible==${VERSION} && \
+    echo "Done install Ansible with deps" && \
     echo "Install CI Helper" && \
     curl -sSL https://github.com/rande/gitlab-ci-helper/releases/download/${CI_HELPER_VERSION}/alpine-amd64-gitlab-ci-helper -o /usr/bin/ci-helper && \
     chmod 755 /usr/bin/ci-helper && \
-    echo "Done install CI Helper"
+    echo "Done install CI Helper" && \
+    rm -rf /var/cache/apk/*

--- a/travis.py
+++ b/travis.py
@@ -140,7 +140,7 @@ def run_build(buildInfo):
         run_args = "--rm"
 
         if language == "ansible":
-            build_args = "%s --build-arg VERSION=%s --build-arg PYTHON_VERSION=%s" % (build_args, buildInfo.version, os.environ.get("PYTHON_VERSION"))
+            build_args = "%s --build-arg VERSION=%s " % (build_args, buildInfo.version)
 
         if language == "arachni":
             build_args = "%s --build-arg VERSION=%s --build-arg ARACHNI_VERSION=%s --build-arg ARACHNI_WEB_UI_VERSION=%s" % (build_args, buildInfo.version, os.environ.get("ARACHNI_VERSION"), os.environ.get("ARACHNI_WEB_UI_VERSION"))


### PR DESCRIPTION
Dockerfile re-arrangement for build passing. This is a quickfix for #172 to pass, this image will need to be upgrade to python 3.x and Ansible 2.7 at least.