### PR TITLE
Fix TRAVIS_TAG env var management

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -10,7 +10,7 @@ def load_ci_env(debug):
     build_info = {
         "commit_range": os.environ.get("TRAVIS_COMMIT_RANGE", "HEAD...HEAD"),
         "branch": os.environ.get("TRAVIS_BRANCH", ""),
-        "tag": os.environ.get("TRAVIS_TAG", "false"),
+        "tag": os.environ.get("TRAVIS_TAG", ""),
         "pull_request": os.environ.get("TRAVIS_PULL_REQUEST", "false"),
         "travis": os.environ.get("TRAVIS", "false"),
         "event_type": os.environ.get("TRAVIS_EVENT_TYPE", ""),
@@ -51,7 +51,7 @@ def load_image_config(image_type, version):
 
 
 def get_image_fullname(image_name, version, image_conf, env_conf):
-    if env_conf["tag"]:
+    if env_conf["tag"] != '':
         fullname = (
             image_conf["docker_hub_namespace"] + ":" + image_name + version + "-" + env_conf["tag"]
         )

--- a/travis.py
+++ b/travis.py
@@ -50,7 +50,7 @@ def build(image, version, debug):
     # - push to master
     # - nightly build
     if (
-        env_conf["tag"] == "true"
+        env_conf["tag"] != ""
         or (env_conf["event_type"] != "pull_request" and env_conf["branch"] == "master")
         or env_conf["event_type"] == "cron"
     ):


### PR DESCRIPTION
Following docker pull issue management from #199, I ended managing TRAVIS_TAG value as a string which value was either "false" or "true".

As it is not how TRAVIS_TAG var works, I revert this change to manage as it should be: empty string if it is not a tag event, not empty if it is.