### PR TITLE
Core: Fix docker login & push in debug mode & upgrade docker client to 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Versions
 * Upgrade Serverless version: 1.51
 * Add aws-cli in serverless image
 * Core: change config file structure to allow volume mounting for local test scripts
+* Core: fix docker login & push in debug mode
+* Core: upgrade docker-py lib from 3.5.0 to 4.0.2
 
 2019-04-05
 ----------

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 pyyaml = "==5.1.1"
 click = "==7.0"
-docker = "==3.5.0"
+docker = "==4.0.2"
 "jinja2" = "==2.10.1"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c9f49d4446a998f59919ab45dd887b09c649d46141c8598b17d2eb8fa7a5c085"
+            "sha256": "91b6c703b025f98cff896237c7032ab8f0205e5f13757446ed902ee77c499bd4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "chardet": {
             "hashes": [
@@ -40,18 +40,11 @@
         },
         "docker": {
             "hashes": [
-                "sha256:6c4da20ef40e8d3eaf650f1488d91452b9a1128045481d7169fd34665ffa90ee",
-                "sha256:bc693be5a84b3b9e5aaf156068c5c0a445ee5138c638c3fbc857133bf67ebe07"
+                "sha256:acf51b5e3e0d056925c3b780067a6f753c915fffaa46c5f2d79eb0fc1cbe6a01",
+                "sha256:cc5b2e94af6a2b1e1ed9d7dcbdc77eff56c36081757baf9ada6e878ea0213164"
             ],
             "index": "pypi",
-            "version": "==3.5.0"
-        },
-        "docker-pycreds": {
-            "hashes": [
-                "sha256:6ce3270bcaf404cc4c3e27e4b6c70d3521deae82fb508767870fdbf772d584d4",
-                "sha256:7266112468627868005106ec19cd0d722702d2b7d5912a28e19b826c3d37af49"
-            ],
-            "version": "==0.4.0"
+            "version": "==4.0.2"
         },
         "idna": {
             "hashes": [

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import pprint
 
@@ -19,7 +20,7 @@ def load_ci_env(debug):
     }
     if debug:
         pp = pprint.PrettyPrinter(indent=1)
-        info_debug = build_info
+        info_debug = copy.copy(build_info)
         info_debug["docker_reg_password"] = "XXX"
         print(">> CI environment configuration: ")
         pp.pprint(info_debug)

--- a/src/docker_image.py
+++ b/src/docker_image.py
@@ -92,7 +92,13 @@ def login_to_registry(env_conf):
 def push_image(image_fullname):
     print("> [Info] Pushing " + image_fullname)
     try:
-        docker_client.images.push(image_fullname)
+        for line in docker_client.images.push(image_fullname, stream=True, decode=True):
+            # Keep 1st and last line of push cmd
+            if "status" in line and "progressDetail" not in line:
+                print(f"{line['status']}")
+            if "error" in line:
+                print(line["error"])
+                exit(1)
         print("Push successful")
     except APIError as api_error:
         print("> [Error] Push failed - " + str(api_error))


### PR DESCRIPTION
- Fix bug when logging in and pushing image to registry in debug mode
- Upgrade docker-py to 4.0.2
- Add logs for docker push as "access denied" doesn't return any error from docker-py