### PR TITLE
chore(security): upgrade golang version to 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Versions
 -----------
 
 * Fix Chrome image build
+* Upgrade Golang version: 1.13.1
 
 2019-09-19
 ----------

--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,6 @@ CI_HELPER_VERSION: &CI_HELPER_VERSION 0.0.6
 ci_helper_test: &ci_helper_test ci-helper version -e
 MODD_VERSION: &MODD_VERSION 0.5
 
-
 ansible:
   "2.5.5":
     build_args:
@@ -109,7 +108,7 @@ golang:
         - gin --version
         - modd --version
     template_vars:
-      GOLANG_VERSION: 1.13
+      GOLANG_VERSION: 1.13.1
 
 java_test_config: &java_test_config
   cmd:


### PR DESCRIPTION
CVE-2019-16276 fix

https://groups.google.com/forum/#!msg/golang-announce/cszieYyuL9Q/g4Z7pKaqAgAJ