### PR TITLE
chore(upgrade): upgrade golang (1.13.4) and serverless (1.57)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Result of template processing
 awslnx-systemd/Dockerfile
+golang/Dockerfile
 java/Dockerfile
 php/Dockerfile
 python/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
     - env: IMAGE=react-native VERSION=1
     - env: IMAGE=ruby VERSION=2.6
     - env: IMAGE=scoutsuite VERSION=5.3
-    - env: IMAGE=serverless VERSION=1.51
+    - env: IMAGE=serverless VERSION=1.57
     - env: IMAGE=sonar VERSION=3.3
     - env: IMAGE=terraform VERSION=0.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 Versions
 ========
 
-2019-10-DEV
+2019-11-DEV
 -----------
 
 * Fix Chrome image build
-* Upgrade Golang version: 1.13.3
+* Upgrade Golang version: 1.13.4
+* Upgrade Serverless version: 1.57
 * Upgrade PHP version: 7.2.23 / 7.3.10
 * Upgrade memcached version: 3.1.4
 * Upgrade ssh2 version: 1.2

--- a/config.yml
+++ b/config.yml
@@ -108,7 +108,7 @@ golang:
         - gin --version
         - modd --version
     template_vars:
-      GOLANG_VERSION: 1.13.3
+      GOLANG_VERSION: 1.13.4
 
 java_test_config: &java_test_config
   cmd:
@@ -310,11 +310,11 @@ scoutsuite:
         - scout --version
 
 serverless:
-  "1.51":
+  "1.57":
     build_args:
       PIP_VERSION: 19.2.1
       PIPENV_VERSION: 2018.11.26
-      SERVERLESS_VERSION: 1.51.0
+      SERVERLESS_VERSION: 1.57.0
     test_config:
       cmd:
         - pip --version


### PR DESCRIPTION
some fixes on golang https://github.com/golang/go/issues?q=milestone%3AGo1.13.4  
and a little upgrade for serveless