### PR TITLE
feat(react-native): upgrade Node/NPM and remove watchman, exposed ports and the custom user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     - env: IMAGE=platformsh VERSION=3.47
     - env: IMAGE=python VERSION=2.7
     - env: IMAGE=python VERSION=3.7
-    - env: IMAGE=react-native VERSION=1
+    - env: IMAGE=react-native VERSION=2
     - env: IMAGE=ruby VERSION=2.6
     - env: IMAGE=scoutsuite VERSION=5.4
     - env: IMAGE=serverless VERSION=1.57

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Versions
 2019-11-DEV
 -----------
 
-todo...
+* Upgrade the React Native image to Node 12.13 and NPM to 6.12.0
+* Remove Watchman, some exposed ports and the custom user from the React Native image
 
 2019-11-18
 -----------

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Contains Python with PIP and PIPENV.
 ### React Native Android
 https://hub.docker.com/r/ekino/ci-react-native/tags
 
-Contains Java 8, Gradle, Android SDK, Node 7.10 and React Native Cli
+Contains Java 8, Gradle, Android SDK, Node 12.13.0 and React Native Cli
 
 ### Ruby
 https://hub.docker.com/r/ekino/ci-ruby/tags

--- a/config.yml
+++ b/config.yml
@@ -274,10 +274,11 @@ python:
       PYTHON_VERSION: 3.7.4
 
 react-native:
-  "1":
+  "2":
     build_args:
       CI_HELPER_VERSION: *CI_HELPER_VERSION
       MODD_VERSION: *MODD_VERSION
+      NODE_VERSION: 12.13.0
     test_config:
       cmd:
         - *ci_helper_test
@@ -287,7 +288,6 @@ react-native:
         - modd --version
         - react-native --version
         - rnpm --version
-        - watchman --version
         - yarn --version
 
 ruby:

--- a/react-native/Dockerfile
+++ b/react-native/Dockerfile
@@ -2,13 +2,13 @@ FROM openjdk:8u171-jdk-slim
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
-    NODE_VERSION="7.10.0" \
-    ANDROID_HOME="/home/user/android-sdk-linux" \
+    ANDROID_HOME="/opt/android-sdk-linux" \
     SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip" \
-    PATH="${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:/home/user/opt/node/bin:${PATH}"
+    PATH="${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:/opt/node/bin:${PATH}"
 
 ARG CI_HELPER_VERSION
 ARG MODD_VERSION
+ARG NODE_VERSION
 
 # ——————————
 # Install base software packages
@@ -96,13 +96,6 @@ RUN dpkg --add-architecture i386 && \
 RUN update-ca-certificates --fresh
 
 # ——————————
-# Create a non-root user
-# ——————————
-RUN useradd -m user
-USER user
-WORKDIR /home/user
-
-# ——————————
 # Download Android SDK
 # ——————————
 RUN mkdir "$ANDROID_HOME" .android && \
@@ -115,24 +108,12 @@ RUN mkdir "$ANDROID_HOME" .android && \
 # ——————————
 # Install Node and global packages
 # ——————————
-RUN cd && \
+RUN cd /tmp && \
     curl -sSL -O http://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz > /dev/null && \
     tar -xzf node-v${NODE_VERSION}-linux-x64.tar.gz && \
-    mkdir opt && \
-    mv node-v${NODE_VERSION}-linux-x64 /home/user/opt/node && \
+    mv node-v${NODE_VERSION}-linux-x64 /opt/node && \
     rm node-v${NODE_VERSION}-linux-x64.tar.gz
 
-# ——————————
-# Installs FB Watchman
-# ——————————
-RUN git clone -b v4.7.0 https://github.com/facebook/watchman.git /home/user/tmp/watchman
-WORKDIR /home/user/tmp/watchman
-RUN ./autogen.sh
-RUN ./configure
-RUN make
-USER root
-RUN make install
-USER user
 
 # ——————————
 # Install Basic React-Native packages
@@ -144,14 +125,12 @@ RUN npm install -g yarn
 # ——————————
 # Mime types
 # ——————————
-USER root
 RUN echo "Adding an up to date mime-types definition file" && \
     curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types
 
 # ——————————
 # Clean files
 # ——————————
-USER root
 RUN echo "Cleaning files!" && \
     rm -rf /tmp/* && \
     apt-get -y remove --purge \
@@ -169,13 +148,7 @@ RUN echo "Cleaning files!" && \
     apt-get -qq clean && apt-get -qq purge && \
     rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old && \
     rm -rf /usr/share/doc /usr/share/locale/[a-df-z]* /usr/share/locale/e[a-lo-z]* /usr/share/locale/en@* /usr/share/locale/en_GB
-USER user
 
 ENV LANG en_US.UTF-8
 
-WORKDIR /home/user/data
-
-# Expose ports
-EXPOSE 8080
-EXPOSE 8082
-EXPOSE 8081
+WORKDIR /data


### PR DESCRIPTION
Hi there,

I did some small things in the React Native image:

* Upgrade Node.js from v7 to v12 (LTS)
* Remove Watchman
* Remove some exposed ports
* Remove the custom user because of issues with root-owned files (eg: cached dependencies from a previous CI job, based on another Docker image)