### PR TITLE
feat(java): add psql to java build image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Versions
 -----------
 
 * Add mysql-client in PHP images
+* Add postgresql-client in java image
 
 2019-12-26
 -----------

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Based upon official Golang image, contains glide, gin, AWS Cli and CI Helper.
 ### Java
 https://hub.docker.com/r/ekino/ci-java/tags
 
-Contains AWS Cli, CI Helper, Maven, Graphviz, jq and Java.
+Contains AWS Cli, CI Helper, Maven, Graphviz, jq, psql and Java.
 
 ### Kubectl
 https://hub.docker.com/r/ekino/ci-kubectl/tags

--- a/config.yml
+++ b/config.yml
@@ -122,6 +122,7 @@ java_test_config: &java_test_config
     - modd --version
     - dot -V
     - jq --version
+    - psql --version
 
 java:
   "8":

--- a/java/Dockerfile.j2
+++ b/java/Dockerfile.j2
@@ -47,6 +47,10 @@ RUN echo "Starting ..." && \
     apt-get -qq -y install graphviz && \
     echo "Done Install graphviz!" && \
 
+    echo "Install postgresql-client" && \
+    apt-get -qq -y install postgresql-client && \
+    echo "Done Install postgresql-client!" && \
+
     echo "Adding an up to date mime-types definition file" && \
     curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types && \
 


### PR DESCRIPTION
`psql` can be useful to add schemas/users/roles on a ci postgres service.
In `gitlab-ci` for example it's not possible to add an init script to a postgres service.