### PR TITLE
chore(cleanup): remove unused Golang packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versions
 * Add mysql-client in PHP images
 * Add postgresql-client in java image
 * Upgrade Golang version: 1.13.6
+* Remove Glide, Gin and Modd from the golang image
 
 2019-12-26
 -----------

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ test:
 ### Golang
 https://hub.docker.com/r/ekino/ci-golang/tags
 
-Based upon official Golang image, contains glide, gin, AWS Cli and CI Helper.
+Based upon official Golang image, contains AWS Cli and CI Helper.
 
 ### Java
 https://hub.docker.com/r/ekino/ci-java/tags

--- a/config.yml
+++ b/config.yml
@@ -100,16 +100,11 @@ golang:
   "1.13":
     build_args:
       CI_HELPER_VERSION: *CI_HELPER_VERSION
-      GLIDE_VERSION: v0.13.3
-      MODD_VERSION: *MODD_VERSION
     test_config:
       cmd:
         - *ci_helper_test
         - aws --version
         - go version
-        - glide --version
-        - gin --version
-        - modd --version
     template_vars:
       GOLANG_VERSION: 1.13.6
 

--- a/golang/Dockerfile.j2
+++ b/golang/Dockerfile.j2
@@ -1,9 +1,7 @@
 FROM golang:{{GOLANG_VERSION}}
 LABEL maintainer="Raphaël Benitte <raphael.benitte@ekino.com>"
 
-ARG GLIDE_VERSION
 ARG CI_HELPER_VERSION
-ARG MODD_VERSION
 
 RUN echo "Starting...\n" && \
 
@@ -17,24 +15,6 @@ RUN echo "Starting...\n" && \
   curl -sSL https://github.com/rande/gitlab-ci-helper/releases/download/${CI_HELPER_VERSION}/linux-amd64-gitlab-ci-helper -o /usr/bin/ci-helper && \
   chmod 755 /usr/bin/ci-helper && \
   echo "Successfully installed CI Helper\n" && \
-
-  echo "Installing glide..." && \
-  mkdir -p /tmp/glide && \
-  curl -sSL https://github.com/Masterminds/glide/releases/download/${GLIDE_VERSION}/glide-${GLIDE_VERSION}-linux-amd64.tar.gz -o /tmp/glide/glide-${GLIDE_VERSION}-linux-amd64.tar.gz && \
-  tar xf /tmp/glide/glide-${GLIDE_VERSION}-linux-amd64.tar.gz -C /tmp/glide && \
-  mv /tmp/glide/linux-amd64/glide /usr/bin && \
-  chmod 755 /usr/bin/glide && \
-  rm -rf /tmp/glide && \
-  echo "Successfully installed glide\n" && \
-
-  echo "Installing gin helper..." && \
-  go get github.com/codegangsta/gin && \
-  echo "Successfully installed gin helper\n" && \
-
-  echo "Installing Modd..." && \
-  curl -sSL https://github.com/cortesi/modd/releases/download/v${MODD_VERSION}/modd-${MODD_VERSION}-linux64.tgz | tar -xOvzf - modd-${MODD_VERSION}-linux64/modd > /usr/bin/modd  && \
-  chmod 755 /usr/bin/modd && \
-  echo "Successfully installed Modd\n" && \
 
   echo "Adding an up to date mime-types definition file" && \
   curl -sSL https://salsa.debian.org/debian/mime-support/raw/master/mime.types -o /etc/mime.types && \


### PR DESCRIPTION
- Glide is not used anymore since we use Go modules
- modd is now installed per project if needed
- Same for gin

Keep updated mime types because it add jsonld mime type

```bash
(docker-buildbox) ➜  docker-buildbox git:(chore/cleanup) orig=$(docker run  golang:1.13.6 bash -c "cat /etc/mime.types"); \                
up=$(curl https://salsa.debian.org/debian/mime-support/raw/master/mime.types); \
diff <(echo $orig) <(echo $up)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 24546  100 24546    0     0  34091      0 --:--:-- --:--:-- --:--:-- 34044
75c75
< application/javascript                                js
---
> application/javascript                                js mjs
76a77
> application/ld+json                           jsonld
```