### PR TITLE
chore: remove support for nodejs 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - env: IMAGE=java VERSION=8
     - env: IMAGE=java VERSION=11
     - env: IMAGE=kubectl VERSION=1.16
-    - env: IMAGE=node VERSION=8
     - env: IMAGE=node VERSION=10
     - env: IMAGE=node VERSION=12
     - env: IMAGE=php VERSION=7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versions
 * Upgrade Golang version: 1.13.6
 * Remove Glide, Gin and Modd from the golang image
 * Upgrade Java 8 to 8u242 and 11 to 11.0.6
+* Remove support for Node 8
 
 2019-12-26
 -----------

--- a/config.yml
+++ b/config.yml
@@ -164,14 +164,6 @@ node_test_config: &node_test_config
     - modd --version
 
 node:
-  "8":
-    build_args:
-      CI_HELPER_VERSION: *CI_HELPER_VERSION
-      NODE_VERSION: 8.16.1
-      NPM_VERSION: 6.12.0
-      NVM_VERSION: 0.34.0
-      MODD_VERSION: *MODD_VERSION
-    test_config: *node_test_config
   "10":
     build_args:
       CI_HELPER_VERSION: *CI_HELPER_VERSION


### PR DESCRIPTION
Nodejs 8 has reached its EOL. IMO it's safe to stop supporting it.