### PR TITLE
Create image for IBM deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ aws/Dockerfile
 azure/Dockerfile
 scoutsuite/Dockerfile
 terraform/Dockerfile
+ibm/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     - env: IMAGE=chrome VERSION=1
     - env: IMAGE=dind-aws VERSION=1
     - env: IMAGE=golang VERSION=1.13
+    - env: IMAGE=ibm VERSION=1.2
     - env: IMAGE=java VERSION=8
     - env: IMAGE=java VERSION=11
     - env: IMAGE=kubectl VERSION=1.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions
 * Upgrade ScoutSuite: 5.7
 * Adding Ansible to 2.9 in addition to 2.8
 * Upgrade Azure CLI to 2.1.0 and Terraform to 0.12.21
+* Create IBM image with terraform, ibm provider and ibmcloud cli
 
 2019-12-26
 -----------

--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ https://hub.docker.com/r/ekino/ci-golang/tags
 
 Based upon official Golang image, contains AWS Cli and CI Helper.
 
+### IBM
+https://hub.docker.com/r/ekino/ci-ibm/tags
+
+Based upon Python image, contains Terraform, IBM Terraform provider located in `/terraform.d/plugins` and ibmcloud cli.
+
+To init Terraform with IBM provider, use:
+```bash
+$ terraform init -provider-path=/terraform.d/plugins
+```
+
 ### Java
 https://hub.docker.com/r/ekino/ci-java/tags
 

--- a/config.yml
+++ b/config.yml
@@ -108,6 +108,20 @@ golang:
     template_vars:
       BASE_IMAGE_VERSION: 1.13.7
 
+ibm:
+  "1.2":
+    build_args:
+      TERRAFORM_VERSION: 0.12.21
+      IBM_PROVIDER_VERSION: 1.2.1
+      IBM_CLI_VERSION: 0.22.0
+    test_config:
+      cmd:
+        - terraform version
+        - python --version
+        - ibmcloud version
+    template_vars:
+      BASE_IMAGE_VERSION: 3.8
+
 java_test_config: &java_test_config
   cmd:
     - *ci_helper_test

--- a/ibm/Dockerfile.j2
+++ b/ibm/Dockerfile.j2
@@ -1,0 +1,27 @@
+FROM python:{{ BASE_IMAGE_VERSION }}-slim-buster
+
+LABEL maintainer="Maxime Sibellas <maxime.sibellas@ekino.com>"
+
+ARG TERRAFORM_VERSION
+ARG IBM_PROVIDER_VERSION
+ARG IBM_CLI_VERSION
+
+RUN pip install -U pip \
+    && pip install awscli boto3 pipenv
+
+RUN apt-get update -qq \
+    && apt-get -y -qq install wget unzip \
+    && echo "Install IBMCloud CLI" \
+    && wget https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/${IBM_CLI_VERSION}/binaries/IBM_Cloud_CLI_${IBM_CLI_VERSION}_linux_amd64.tgz \
+    && tar -xzf IBM_Cloud_CLI_${IBM_CLI_VERSION}_linux_amd64.tgz  -C /usr/local/bin --strip-components 1 IBM_Cloud_CLI/ibmcloud \
+    && rm -rf IBM_Cloud_CLI_${IBM_CLI_VERSION}_linux_amd64.tgz \
+    && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip \
+    && unzip terraform.zip -d /usr/bin/ \
+    && rm terraform.zip \
+    && chmod +x /usr/bin/terraform \
+    && wget https://github.com/IBM-Cloud/terraform-provider-ibm/releases/download/v${IBM_PROVIDER_VERSION}/linux_amd64.zip \
+    && mkdir -p /terraform.d/plugins \
+    && unzip linux_amd64.zip -d /terraform.d/plugins \
+    && rm linux_amd64.zip \
+    && apt-get -y -qq remove unzip wget && apt-get -y -qq autoremove \
+    && apt-get clean


### PR DESCRIPTION
Create image to deploy infra on IBM Cloud using Terraform 0.12, IBM terraform provider and IBM Cloud CLI.