### PR TITLE
Add git in AWS Image

### DIFF
--- a/aws/Dockerfile.j2
+++ b/aws/Dockerfile.j2
@@ -2,7 +2,7 @@ FROM python:{{ BASE_IMAGE_VERSION }}-slim-buster
 LABEL maintainer="Frank Pavageau <fpavageau@ekino.com>"
 
 RUN echo "Install AWS" && \
-    apt-get update -qq && apt-get install -qq -y curl && \
+    apt-get update -qq && apt-get install -qq -y curl git && \
     pip install -U pip && \
     pip install pipenv awscli boto3 awsebcli PyYAML && \
     echo "Done install AWS" && \

--- a/config.yml
+++ b/config.yml
@@ -43,6 +43,7 @@ aws:
         - aws --version
         - pip --version
         - pipenv --version
+        - git --version
     template_vars:
       BASE_IMAGE_VERSION: 3.8
 


### PR DESCRIPTION
We discovered on ekino/ci-aws:latest that we cannot make troposphere diffs as it needs git and git isn't part of debian:buster-slim.