### PR TITLE
feat(docker): increase docker client timeout to 10 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Versions
 * Move ibm image to Golang base image and build Null provider
 * Upgrade ibm provider to 1.2.4
 * Upgrade eksctl to 0.14.0
-* feat(ci): migrate to github actions
+* Migrate the CI to GitHub Actions
+* Increase DockerClient's timeout to 10 minutes
 
 2020-02-28
 -----------

--- a/src/docker_image.py
+++ b/src/docker_image.py
@@ -4,7 +4,7 @@ import pprint
 from docker import DockerClient
 from docker.errors import APIError, BuildError, ContainerError
 
-docker_client = DockerClient(base_url="unix://var/run/docker.sock")
+docker_client = DockerClient(base_url="unix://var/run/docker.sock", timeout=600)
 
 
 def build_image(image_conf, image_fullname, dockerfile, debug):


### PR DESCRIPTION
Our CI is now faster, and we now have random timeouts when pushing to docker hub multiple times in parallel : https://github.com/ekino/docker-buildbox/runs/539228402?check_suite_focus=true

It seems to be a known issue : https://github.com/docker/docker-py/issues/2096

The default timeout is 60 seconds, and this commit will increase it to 600 seconds.