### PR TITLE
feat(ci): create a single workflow for checking all the other statuses

### DIFF
--- a/.github/workflows/build-checker.yml
+++ b/.github/workflows/build-checker.yml
@@ -1,0 +1,25 @@
+name: Build Checker
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for commit statuses
+        id: status
+        uses: WyriHaximus/github-action-wait-for-status@d2ddfe5
+        with:
+          ignoreActions: check
+          checkInterval: 60
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Succeed
+        if: steps.status.outputs.status == 'success'
+        run: exit 0
+      - name: Fail
+        if: steps.status.outputs.status == 'failure'
+        run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versions
 * Increase DockerClient's timeout to 10 minutes
 * Rename dind-aws to dind and add all provider cli (aws, ibm, azure)
 * Add Helm cli to kubectl image
+* Add a workflow dedicated to checking PR mergeability
 
 2020-02-28
 -----------


### PR DESCRIPTION
Today, having one build per image configuration raises two issues:
* When we add a new configuration or remove an existing one, **a repository owner has to manually update the required checks** for merging a PR. See https://github.com/ekino/docker-buildbox/pull/274#issuecomment-609871057
* When we'll be able to build only the images that were modified, **the checks requirements won't be satisfied**. See https://github.com/ekino/docker-buildbox/pull/271#issuecomment-610286063

The goal of this PR is to create a new workflow whose one and only role is to check the statuses of every other jobs for the commit: Build Checker.
We will then be able to require only this check to succeed before merging, solving all our problems that way.

I used an action that does exactly that:
* Repository: https://github.com/WyriHaximus/github-action-wait-for-status
* Marketplace: https://github.com/marketplace/actions/wait-for-commit-statuses
* The code actually executed: https://github.com/WyriHaximus/github-action-wait-for-status/blob/master/wait.php. It uses GitHub's API Client to check every X seconds if our workflows are finished and their statuses.

At the moment, we have to target a specific commit (on master, so it's ok :ok_hand:), since they didn't release one of their fixes in a tagged version yet (see TODO).

I've set it up to check the statuses of every jobs (except itself) every 60 seconds, and to be triggered only on `pull_request`.


TODO:
- [x] ~~PR description~~ Done
- [x] ~~Test the behaviour when all jobs succeed~~ Done: Build Checker succeeds as intended.
  - Succeeding jobs: https://github.com/ekino/docker-buildbox/actions/runs/72738237 and https://github.com/ekino/docker-buildbox/actions/runs/72738163
  - Succeeding check: https://github.com/ekino/docker-buildbox/actions/runs/72738228
- [x] ~~Test the behaviour when a jobs fails~~ Done: Build Checker fails as intended
  - Failing job: https://github.com/ekino/docker-buildbox/runs/567622082?check_suite_focus=true
  - Failing check: https://github.com/ekino/docker-buildbox/runs/567621922?check_suite_focus=true
- [x] ~~Fix the check interval (input not used)~~ Done: Fixed with https://github.com/WyriHaximus/github-action-wait-for-status/pull/4, but not released yet. We'll use a commit reference for the moment.
- [x] Ask (kindly. optional but recommended) a repository owner to update the required checks (for the last time :tada:).