### PR TITLE
chore(ci): update the action used by build-checker

### DIFF
--- a/.github/workflows/build-checker.yml
+++ b/.github/workflows/build-checker.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Wait for commit statuses
         id: status
-        uses: WyriHaximus/github-action-wait-for-status@d2ddfe5
+        uses: WyriHaximus/github-action-wait-for-status@4c9e588
         with:
           ignoreActions: check
           checkInterval: 60


### PR DESCRIPTION
Update the version of https://github.com/WyriHaximus/github-action-wait-for-status to fix an issue happening randomly on race conditions: https://github.com/WyriHaximus/github-action-wait-for-status/issues/3. Still no new release from them by the way, we'll have to keep using a commit sha. 

I encountered this issue a lot while working on https://github.com/ekino/docker-buildbox/pull/271.
![image](https://user-images.githubusercontent.com/3366767/81090933-c53a6f80-8efe-11ea-8fb5-2a2d2ff5b859.png)