### PR TITLE
chore(ci): lint matrix and new include override

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,35 +16,35 @@ jobs:
 
     strategy:
       matrix:
-        config:
-          - {IMAGE: ansible, VERSION: 2.9}
-          - {IMAGE: aws, VERSION: 1}
-          - {IMAGE: awslnx-systemd, VERSION: 2}
-          - {IMAGE: azure, VERSION: 2}
-          - {IMAGE: chrome, VERSION: 1}
-          - {IMAGE: dind, VERSION: 1}
-          - {IMAGE: golang, VERSION: 1.14}
-          - {IMAGE: ibm, VERSION: 1.4}
-          - {IMAGE: java, VERSION: 8}
-          - {IMAGE: java, VERSION: 11}
-          - {IMAGE: kubectl, VERSION: 1.18}
-          - {IMAGE: node, VERSION: 10}
-          - {IMAGE: node, VERSION: 12}
-          - {IMAGE: php, VERSION: 7.2}
-          - {IMAGE: php, VERSION: 7.3}
-          - {IMAGE: php, VERSION: 7.4}
-          - {IMAGE: platformsh, VERSION: "3.50"}
-          - {IMAGE: pynode, VERSION: 3.7}
-          - {IMAGE: pynode, VERSION: 3.8}
-          - {IMAGE: python, VERSION: 3.7}
-          - {IMAGE: python, VERSION: 3.8}
-          - {IMAGE: python, VERSION: 2.7}
-          - {IMAGE: python, VERSION: 3.7}
-          - {IMAGE: react-native, VERSION: 2}
-          - {IMAGE: ruby, VERSION: 2.6}
-          - {IMAGE: scoutsuite, VERSION: 5.8}
-          - {IMAGE: sonar, VERSION: 3.3}
-          - {IMAGE: terraform, VERSION: 0.12}
+        include:
+          - { image: ansible, version: 2.9 }
+          - { image: aws, version: 1 }
+          - { image: awslnx-systemd, version: 2 }
+          - { image: azure, version: 2 }
+          - { image: chrome, version: 1 }
+          - { image: dind, version: 1 }
+          - { image: golang, version: 1.14 }
+          - { image: ibm, version: 1.4 }
+          - { image: java, version: 8 }
+          - { image: java, version: 11 }
+          - { image: kubectl, version: 1.18 }
+          - { image: node, version: 10 }
+          - { image: node, version: 12 }
+          - { image: php, version: 7.2 }
+          - { image: php, version: 7.3 }
+          - { image: php, version: 7.4 }
+          - { image: platformsh, version: "3.50" }
+          - { image: pynode, version: 3.7 }
+          - { image: pynode, version: 3.8 }
+          - { image: python, version: 3.7 }
+          - { image: python, version: 3.8 }
+          - { image: python, version: 2.7 }
+          - { image: python, version: 3.7 }
+          - { image: react-native, version: 2 }
+          - { image: ruby, version: 2.6 }
+          - { image: scoutsuite, version: 5.8 }
+          - { image: sonar, version: 3.3 }
+          - { image: terraform, version: 0.12 }
 
     steps:
       - uses: actions/checkout@v2
@@ -58,9 +58,7 @@ jobs:
           pipenv sync
       - name: Build and tests images
         env:
-          IMAGE: ${{ matrix.config.IMAGE }}
-          VERSION: ${{ matrix.config.VERSION }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-          pipenv run python image_builder.py build -d --image ${IMAGE} --version ${VERSION}
+          pipenv run python image_builder.py build -d --image ${{ matrix.image }} --version ${{ matrix.version }}


### PR DESCRIPTION
According to a Github dev (https://github.com/actions/runner/issues/343#issuecomment-590634907), we can now directly use `include` to create new matrix entries like we did on Travis :tada:.

I also removed useless intermediate env variables and linted the matrix a bit to change the case and have a clean "column" look.

While we're at it : Do you prefer the "column style" or the "list style", or the previous style?

Column style (really easy to read, but awful to maintain):
```
strategy:
  matrix:
    include:
      - { image: ansible, version: 2.9  }
      - { image: aws    , version: 1    }
      - { image: aws    , version: 2    }
      - { image: aws    , version: 3    }
      - { image: chrome , version: 1    }
      - { image: dind   , version: 1    }
      - { image: golang , version: 1.14 }
```

List style (not really easy to read, but easy to maintain):
```
strategy:
  matrix:
    include:
      - image: ansible
        version: 2.9
      - image: aws
        version: 1
      - image: aws
        version: 2
      - image: aws
        version: 3
      - image: chrome
        version: 1
      - image: dind
        version: 1
      - image: golang
        version: 1.14
```

Previous style (easily see which image has multiple versions, easy to maintain):
```
strategy:
  matrix:
    include:
      - { image: ansible, version: 2.9 }
      - { image: aws, version: 1 }
      - { image: aws, version: 2 }
      - { image: aws, version: 3 }
      - { image: chrome, version: 1 }
      - { image: dind, version: 1 }
      - { image: golang, version: 1.14 }
```

**Let's vote** with :heart: for column style, with :rocket: for list style and with :tada: for the previous style !