### PR TITLE
fix(tezosqa): update smartpy install script url

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -395,4 +395,4 @@ tezosqa:
       BASE_IMAGE_VERSION: 3.8
     test_config:
       cmd:
-        - /opt/SmartPy/SmartPy.sh self-test
+        - /opt/SmartPy/SmartPy.sh --version

--- a/tezosqa/Dockerfile.j2
+++ b/tezosqa/Dockerfile.j2
@@ -13,7 +13,7 @@ RUN echo "Install system dependencies for python and pip" && \
     apt-get install -q -y curl && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs && \
-    curl -s https://SmartPy.io/smartpy-cli-dev/SmartPy.sh | bash -s local-install-dev /opt/SmartPy && \
+    curl -s https://smartpy.io/dev/cli/SmartPy.sh | bash -s local-install-auto /opt/SmartPy && \
     echo "export PATH=/opt/SmartPy:\$PATH" >> /etc/profile && \
     echo "Done!" && \
     echo "Install ligo" && \


### PR DESCRIPTION
Hello, Here is a little update to fix docker-buildbox builds, as the install script currently returns a not found error