### PR TITLE
fix(ci): use v1 for WyriHaximus/github-action-wait-for-status

### DIFF
--- a/.github/workflows/build-checker.yml
+++ b/.github/workflows/build-checker.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Wait for commit statuses
         id: status
-        uses: WyriHaximus/github-action-wait-for-status@d2ddfe5
+        uses: WyriHaximus/github-action-wait-for-status@v1
         with:
           ignoreActions: check
           checkInterval: 60


### PR DESCRIPTION
cc @Crow-EH 

Using v1 is supposed to resolve https://github.com/WyriHaximus/github-action-wait-for-status/issues/3

We currently have those kind of failures (see https://github.com/ekino/docker-buildbox/pull/309/checks?check_run_id=919006633 for example).