### PR TITLE
fix(check): failing jobs not detected

### DIFF
--- a/.github/workflows/build-checker.yml
+++ b/.github/workflows/build-checker.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Wait for commit statuses
         id: status
-        uses: WyriHaximus/github-action-wait-for-status@v1
+        uses: WyriHaximus/github-action-wait-for-status@v1.2
         with:
           ignoreActions: check
           checkInterval: 60


### PR DESCRIPTION
Failing jobs are not detected by our build checker (the only job required to pass for merging any PR).

Upgrading wait-for-status to 1.2 fixes it: https://github.com/WyriHaximus/github-action-wait-for-status/issues/21

Here is a pull request reproducing the issue: https://github.com/Crow-EH/github-action-wait-for-status-issue-21/pull/1

And here is the same thing in v1.2: https://github.com/Crow-EH/github-action-wait-for-status-issue-21/pull/19