### PR TITLE
fix(awscli): make sure python is still present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versions
 * Upgrade php-cs-fixer version to 2.16.7
 * Upgrade Xdebug version to version 2.9.8
 * Delete Composer plugin hirak/prestissimo
+* Fix missing awscli missing from Node and React Native
 
 2020-10-31
 -----------

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -64,7 +64,7 @@ RUN echo "Starting ..." && \
     apt-get -qq -y remove --purge emacsen-common fakeroot file firebird3.0-common firebird3.0-common-doc \
       firebird3.0-server firebird3.0-server-core man-db manpages manpages-dev \
       default-mysql-client mysql-common default-mysql-server default-mysql-server-core odbcinst odbcinst1debian2 \
-      patch po-debconf psmisc python-pip xauth xtrans-dev xz-utils zlib1g-dev && \
+      patch po-debconf psmisc xauth xtrans-dev xz-utils zlib1g-dev && \
 
     apt-get -qq -y autoremove && \
     apt-get -qq clean && apt-get -qq purge && \

--- a/react-native/Dockerfile
+++ b/react-native/Dockerfile
@@ -139,7 +139,6 @@ RUN echo "Cleaning files!" && \
         file \
         manpages \
         manpages-dev \
-        python-pip \
         patch \
         xauth \
         xz-utils && \


### PR DESCRIPTION
The current `node` image include the `awscli` in the build, however removing `python-pip` and `auto-remove` remove the python interpretor from the final image

```
docker run -ti --rm ekino/ci-node:12-2020.09.30 /bin/bash -c 'aws'                                               
/bin/bash: /usr/local/bin/aws: /usr/bin/python: bad interpreter: No such file or directory
```

This PR does not remove the `python-pip` so the python packages are not flagged to be deleted.
