### PR TITLE
feat: upgrade Taskfile to v3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versions
 * Python : update base image versions
 * Chrome : update puppeteer to 1.13 to fix CVE
 * React-native : update base image to openjdk:8u282-jdk-slim (CVE fix)
+* BREAKING CHANGE: Upgrade Taskfile to v3.2.2 (drop compatibility with v1.x.x definition files)
 
 2021-01-25
 -----------

--- a/config.yml
+++ b/config.yml
@@ -5,7 +5,7 @@ docker_hub_namespace: &docker_hub_namespace ekino
 CI_HELPER_VERSION: &CI_HELPER_VERSION 0.0.6
 ci_helper_test: &ci_helper_test ci-helper version -e
 MODD_VERSION: &MODD_VERSION 0.5
-TASKFILE_VERSION: &TASKFILE_VERSION 2.8.1
+TASKFILE_VERSION: &TASKFILE_VERSION 3.2.2
 
 ansible_tests: &ansible_tests
   cmd:


### PR DESCRIPTION
**Note:** version >= 3.0.0 does not support Taskfiles written for the first version anymore
https://taskfile.dev/#/taskfile_versions?id=version-1