### PR TITLE
docs(readme): use new actions badge url and fix link to include scheduled jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/ekino/docker-buildbox/workflows/Build%20and%20test%20images/badge.svg)](https://github.com/ekino/docker-buildbox/actions?query=branch%3Amaster+event%3Apush)
+[![Build Status](https://github.com/ekino/docker-buildbox/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/ekino/docker-buildbox/actions?query=branch%3Amaster)
 
 # BuildBox
 


### PR DESCRIPTION
New URL is cleaner IMO https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge