### PR TITLE
ci(build): no build when all files excluded and exclude dependabot conf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' || github.event_name == 'pull_request'
+    if: (github.actor != 'dependabot[bot]' || github.event_name == 'pull_request') && fromJSON(needs.generate_matrix.outputs.matrix).include[0]
     needs: generate_matrix
 
     strategy:


### PR DESCRIPTION
This allows making PR for excluded files only without building every images (see #524).
Also excludes dependabot config for #514.

The check that `include` has at least one item is because Github Actions will fail on empty matrixes (job's `if` is interpreded before matrix expansion).

Tests:
* https://github.com/Crow-EH/docker-buildbox/pull/2
* https://github.com/Crow-EH/docker-buildbox/pull/3
* https://github.com/Crow-EH/docker-buildbox/pull/4

Blocked by #523