### PR TITLE
ci(dependabot): enable auto merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-checker.yml
+++ b/.github/workflows/build-checker.yml
@@ -13,7 +13,7 @@ jobs:
         id: status
         uses: WyriHaximus/github-action-wait-for-status@v1.4
         with:
-          ignoreActions: check
+          ignoreActions: check,dependabot
           checkInterval: 60
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,8 @@ jobs:
 
   generate_matrix:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' || github.event_name == 'pull_request'
+    # Dependabot triggers jobs only on master branch or pull_request events
+    if: github.actor != 'dependabot[bot]' || github.ref == 'refs/heads/master' || github.event_name == 'pull_request'
 
     steps:
       - name: Checkout
@@ -38,7 +39,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]' || github.event_name == 'pull_request') && fromJSON(needs.generate_matrix.outputs.matrix).include[0]
+    # Runs only if the matrix is not empty
+    if: (github.actor != 'dependabot[bot]' || github.ref == 'refs/heads/master' || github.event_name == 'pull_request') && fromJSON(needs.generate_matrix.outputs.matrix).include[0]
     needs: generate_matrix
 
     strategy:


### PR DESCRIPTION
**This is a work in progress.**

Based on [GA doc's example](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request).

The `pull_request_target` event is like `pull_request` except it allows write permissions.

`gh pr merge --auto --merge "$PR_URL"` will enable auto-merging of the PR that triggered the event. The merge will occur only after all the required conditions are fulfilled (in our case the build checker workflow). Doc : https://cli.github.com/manual/gh_pr_merge

The metadata step allows to filter by update types in the second step, I configured it to auto-merge minor and patch only. [There's seemingly no way to filter on package-ecosystem (like `docker`) atm](https://github.com/dependabot/fetch-metadata/issues/76), so we'll have to set auto-merge on every dependabot's PR or find an alternative if we want to filter.

**[Will require allowing auto-merge in repository settings.](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository#managing-auto-merge)**

### TODO
- [ ] Tweak the auto-merge behaviour (merged by `github-actions[bot]`) to trigger the `master` workflow, if possible and deemed necessary. WDYT @axelpavageau, would the PR workflow + scheduled workflow be enough ? It would publish on nightly only if I remember right, until next human merge or tag.
- [ ] Try if it still works with only `pull-requests: write` permission
- [ ] Try if `action` permission scope affects the triggering of master workflow after auto-merge by the bot

### Tests
On my fork with auto-merge and dependabot enabled :
* The auto-merge has been set but the PR is not merged automatically because the required check are not passing : https://github.com/Crow-EH/docker-buildbox/pull/3 ✅ 
* The auto-merge has been set and the PR is merged automatically after the required check passes : https://github.com/Crow-EH/docker-buildbox/pull/5 ✅ But [the merge on master did not trigger a workflow](https://github.com/Crow-EH/docker-buildbox/commit/ee2185d794fbd60b74889f4474999c0c65dbc157). ⚠️ 
* A PR with auto-merge set by me also merged after check : https://github.com/Crow-EH/docker-buildbox/pull/6 ✅ AND[ the merge did trigger a workflow](https://github.com/Crow-EH/docker-buildbox/commit/6218bb0f662340eae3a78f956342929ce023567c) ✅ It seems that the issue in the second test is that  `github-actions[bot]` was the one setting auto-merge