### PR TITLE
Aws build arm64 docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versions
 * AWS : Build arm64 docker image
 * Golang: adding new 1.19 flavor
 * Platformsh: updating base image, and CLI to the latest 3.81.x
-* AWS : Fix build for docker hub error
+* AWS : Fix tagging issue preventing the push of multiple architectures to docker hub
 
 2022-07-31
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versions
 * AWS : Build arm64 docker image
 * Golang: adding new 1.19 flavor
 * Platformsh: updating base image, and CLI to the latest 3.81.x
-* AWS : Fix lack of amd64 arch on docker hub
+* AWS : Fix build for docker hub error
 
 2022-07-31
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions
 * AWS : Build arm64 docker image
 * Golang: adding new 1.19 flavor
 * Platformsh: updating base image, and CLI to the latest 3.81.x
+* AWS : Fix lack of amd64 arch on docker hub
 
 2022-07-31
 ----------

--- a/image_builder.py
+++ b/image_builder.py
@@ -4,6 +4,7 @@ import click
 
 import src.config as config
 import src.docker_tools as docker_tools
+from python_on_whales import docker
 
 
 @click.command()
@@ -38,9 +39,22 @@ def build(image, version, debug):
         # Build docker image
         docker_tools.build_image(
             image_conf, image_tags, dockerfile_directory, dockerfile_path, debug)
+        
 
         # Run defined test command
         docker_tools.run_image(image_tags["localname"], image_conf, debug)
+
+
+        localTagManifest = docker.buildx.imagetools.inspect(image_tags["localname"])
+        print("local tag manifest")
+        print(localTagManifest)
+
+        docker_tools.tag_image(image_tags["localname"], image_tags["fullname"])
+        #docker.buildx.imagetools.create(image_tags["localname"], tags=image_tags["fullname"])
+
+        remoteTagManifest = docker.buildx.imagetools.inspect(image_tags["fullname"])
+        print("remote tag manifest")
+        print(remoteTagManifest)
 
         # Push to registry in case of:
         # - tag

--- a/src/docker_tools.py
+++ b/src/docker_tools.py
@@ -33,9 +33,8 @@ def build_image(image_conf, image_tags, dockerfile_directory, dockerfile_path, d
             cache=False,
             push=True,
             build_args=image_conf["build_args"] if "build_args" in image_conf else {
-            },
-            platforms=image_conf["platforms"]
-        )
+            }, platforms=image_conf["platforms"]
+        )  
 
     except DockerException as docker_exception:
         print("> [Error] Build error - " + str(docker_exception))

--- a/src/docker_tools.py
+++ b/src/docker_tools.py
@@ -5,8 +5,8 @@ from python_on_whales import docker
 from python_on_whales.exceptions import DockerException
 
 
-def build_image(image_conf, image_tags, dockerfile_directory, dockerfile_path, debug):
-    print("> [Info] Building: " + image_tags["fullname"])
+def build_image(image_conf, image_tag, dockerfile_directory, dockerfile_path, debug):
+    print("> [Info] Building: " + image_tag)
     try:
         if debug:
             pp = pprint.PrettyPrinter(indent=1)
@@ -29,7 +29,7 @@ def build_image(image_conf, image_tags, dockerfile_directory, dockerfile_path, d
             builder=builder,
             file=os.path.join(dockerfile_directory, dockerfile_path),
             context_path=dockerfile_directory,
-            tags=image_tags["localname"],
+            tags=image_tag,
             cache=False,
             push=True,
             build_args=image_conf["build_args"] if "build_args" in image_conf else {


### PR DESCRIPTION
Issues : 
* AWS : Fix lack of amd64 arch on docker hub

Issue origin :
The conventional docker retag/push strategy https://github.com/ekino/docker-buildbox/blob/master/image_builder.py#L55-L56 only keeps the image manifest for the architecture platform of the system from which I perform the retag/push (in this case arm64)

