### PR TITLE
chore(php): add php 8.2 image & remove 7.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -225,17 +225,6 @@ updates:
         update-types: ["version-update:semver-major"]
   # Php
   - package-ecosystem: "docker"
-    directory: "/php/7.4"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "docker"
-      - "php"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  - package-ecosystem: "docker"
     directory: "/php/8.0"
     schedule:
       interval: "weekly"
@@ -257,6 +246,17 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  -   package-ecosystem: "docker"
+      directory: "/php/8.2"
+      schedule:
+        interval: "weekly"
+      labels:
+        - "dependencies"
+        - "docker"
+        - "php"
+      ignore:
+        -   dependency-name: "*"
+            update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Platformsh
   - package-ecosystem: "docker"
     directory: "/platformsh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Versions
 2023-01-31
 ----------
 * Ansible: bumping from 5.x.x to 7.x.x
+* PHP: adding support for php 8.2 and removing for 7.4. Php-cs-fixer isn't officially supported in 8.2 as of now, use it with care. 
 
 2022-12-31
 ----------

--- a/php/8.0/Dockerfile
+++ b/php/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.26-cli-alpine3.15 AS base
+FROM php:8.0.27-cli-alpine3.16 AS base
 LABEL maintainer="Rémi Marseille <marseille@ekino.com>"
 
 ARG APCU_VERSION

--- a/php/8.1/Dockerfile
+++ b/php/8.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.13-cli-alpine3.15 AS base
+FROM php:8.1.14-cli-alpine3.17 AS base
 LABEL maintainer="Rémi Marseille <marseille@ekino.com>"
 
 ARG APCU_VERSION

--- a/php/8.2/Dockerfile
+++ b/php/8.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.33-cli-alpine3.15 AS base
+FROM php:8.2.1-cli-alpine3.17 AS base
 LABEL maintainer="Rémi Marseille <marseille@ekino.com>"
 
 ARG APCU_VERSION
@@ -28,7 +28,9 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_MEMORY_LIMIT=-1 \
     TERM=xterm \
     LD_PRELOAD="/usr/lib/preloadable_libiconv.so php" \
-    PHP_CPPFLAGS="$PHP_CPPFLAGS -std=c++11"
+    PHP_CPPFLAGS="$PHP_CPPFLAGS -std=c++11" \
+    # TODO: remove this once php-cs-fixer is officially supporting PHP 8.2
+    PHP_CS_FIXER_IGNORE_ENV=1
 
 COPY run.sh .
 RUN sh run.sh

--- a/php/config.yml
+++ b/php/config.yml
@@ -1,3 +1,7 @@
+platforms: &platforms
+  - linux/amd64
+  - linux/arm64
+
 test_config: &test_config
   volume: php:/tmp
   cmd:
@@ -9,34 +13,32 @@ test_config: &test_config
     - php /tmp/test.php
 
 build_args: &build_args
-  APCU_VERSION: 5.1.21
-  COMPOSER_VERSION: 2.3.8
+  APCU_VERSION: 5.1.22
+  COMPOSER_VERSION: 2.5.1
   ICONV_VERSION: 1.15-r3
   MEMCACHED_VERSION: 3.2.0
   MODD_VERSION: *MODD_VERSION
-  MUSL_VERSION: 1.2.2-r7
-  PHP_CS_FIXER_VERSION: 3.8.0
+  PHP_CS_FIXER_VERSION: 3.13.2
   REDIS_VERSION: 5.3.7
-  SECURITY_CHECKER_VERSION: 2.0.4
-  SSH2_VERSION: 1.3.1
-  XDEBUG_VERSION: 3.1.5
+  SECURITY_CHECKER_VERSION: 2.0.6
+  XDEBUG_VERSION: 3.2.0
 
 versions:
-  "7.4":
-    platforms:
-      - linux/amd64
-      - linux/arm64
-    build_args: *build_args
-    test_config: *test_config
   "8.0":
-    platforms:
-      - linux/amd64
-      - linux/arm64
-    build_args: *build_args
+    platforms: *platforms
+    build_args:
+      <<: *build_args
+      MUSL_VERSION: 1.2.3-r2
     test_config: *test_config
   "8.1":
-    platforms:
-      - linux/amd64
-      - linux/arm64
-    build_args: *build_args
+    platforms: *platforms
+    build_args:
+      <<: *build_args
+      MUSL_VERSION: 1.2.3-r4
+    test_config: *test_config
+  "8.2":
+    platforms: *platforms
+    build_args:
+      <<: *build_args
+      MUSL_VERSION: 1.2.3-r4
     test_config: *test_config

--- a/php/run.sh
+++ b/php/run.sh
@@ -8,7 +8,7 @@ echo "@edge-community http://nl.alpinelinux.org/alpine/edge/community" >> /etc/a
 echo "@edge-community-3.13 http://nl.alpinelinux.org/alpine/v3.13/community" >> /etc/apk/repositories
 apk add --update --upgrade alpine-sdk apk-tools@edge-main autoconf bash bzip2 cyrus-sasl-dev curl freetype-dev gettext git \
     gnu-libiconv@edge-community-3.13==${ICONV_VERSION} icu-dev jq libgcrypt-dev libcrypto1.1 libjpeg-turbo-dev \
-    libmcrypt-dev libmemcached-dev libpng-dev libssh2-dev libssl1.1 libxml2-dev libxslt-dev libzip-dev make \
+    libmcrypt-dev libmemcached-dev libpng-dev libssh2-dev libssl1.1 libxml2-dev libxslt-dev libzip-dev linux-headers make \
     musl-dev==${MUSL_VERSION} mysql-client openssh-client patch postgresql-client postgresql-dev rsync tzdata
 echo "Done base install!"
 
@@ -32,11 +32,6 @@ pecl install pcov
 docker-php-ext-enable pcov
 docker-php-ext-enable memcached
 docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql
-
-if [ "$version" = "74" ]; then
-    pecl install ssh2-${SSH2_VERSION};
-    docker-php-ext-enable ssh2;
-fi
 
 echo -e "\
 date.timezone=${PHP_TIMEZONE:-UTC} \n\


### PR DESCRIPTION
- Add `linux-headers` because of :
[configure: error: rtnetlink.h is required, install the linux-headers package: apk add --update linux-headers](https://github.com/vladsolntsev/docker-buildbox/actions/runs/3940339455/jobs/6741325494#step:7:5753)
that caused xdebug and blackfire to not install properly

- PHP 8.0 doesn't have any official image on Alpine 3.17, and different musl versions are needed on Alpine 3.16 and 3.17. 

- Everything builds for 8.2 but php-cs-fixer that isn't fully ready yet for 8.2 (https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6749). Set PHP_CS_FIXER_IGNORE_ENV to bypass the warnings.
