### PR TITLE
chore(php): Add the icu-data-full package into the PHP images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Versions
 
 2024-05-31
 ----------
-* PHP : adding **gettext** extension and **gettext-dev** package for PHP 8.1 image
+* PHP : adding **icu-data-full** package for PHP 8.1|8.2|8.3 image
 
 2024-04-30
 ----------

--- a/php/8.1/Dockerfile
+++ b/php/8.1/Dockerfile
@@ -32,8 +32,8 @@ ENV COMPOSER_NO_INTERACTION=1 \
 
 
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") && \
-    apk add --update --upgrade alpine-sdk apk-tools autoconf bash bzip2 cyrus-sasl-dev curl freetype-dev gettext gettext-dev git \
-    gnu-libiconv==${ICONV_VERSION} icu-dev jq libgcrypt-dev libcrypto1.1 libjpeg-turbo-dev \
+    apk add --update --upgrade alpine-sdk apk-tools autoconf bash bzip2 cyrus-sasl-dev curl freetype-dev gettext git \
+    gnu-libiconv==${ICONV_VERSION} icu-dev icu-data-full jq libgcrypt-dev libcrypto1.1 libjpeg-turbo-dev \
     libmcrypt-dev libmemcached-dev libpng-dev libssh2-dev libssl1.1 libxml2-dev libxslt-dev libzip-dev linux-headers make \
     musl-dev==${MUSL_VERSION} mysql-client openssh-client patch postgresql-client postgresql-dev rsync tzdata && \
     # Install Modd"
@@ -43,7 +43,7 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") && \
     docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ && \
     CFLAGS_PREVIOUS=$CFLAGS && \
     export CFLAGS="$CFLAGS -D_GNU_SOURCE" && \
-    docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) bcmath exif gd intl gettext mysqli pcntl pdo_mysql pdo_pgsql pgsql soap sockets xsl zip && \
+    docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) bcmath exif gd intl mysqli pcntl pdo_mysql pdo_pgsql pgsql soap sockets xsl zip && \
     export CFLAGS=$CFLAGS_PREVIOUS && \
     pecl install apcu-${APCU_VERSION} && \
     pecl install memcached-${MEMCACHED_VERSION} && \

--- a/php/8.2/Dockerfile
+++ b/php/8.2/Dockerfile
@@ -33,7 +33,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
 
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") && \
     apk add --update --upgrade alpine-sdk apk-tools autoconf bash bzip2 cyrus-sasl-dev curl freetype-dev gettext git \
-    gnu-libiconv==${ICONV_VERSION} icu-dev jq libgcrypt-dev libcrypto1.1 libjpeg-turbo-dev \
+    gnu-libiconv==${ICONV_VERSION} icu-dev icu-data-full jq libgcrypt-dev libcrypto1.1 libjpeg-turbo-dev \
     libmcrypt-dev libmemcached-dev libpng-dev libssh2-dev libssl1.1 libxml2-dev libxslt-dev libzip-dev linux-headers make \
     musl-dev==${MUSL_VERSION} mysql-client openssh-client patch postgresql-client postgresql-dev rsync tzdata && \
     # Install Modd"

--- a/php/8.3/Dockerfile
+++ b/php/8.3/Dockerfile
@@ -32,7 +32,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
 
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") && \
     apk add --update --upgrade alpine-sdk apk-tools autoconf bash bzip2 cyrus-sasl-dev curl freetype-dev gettext git \
-    gnu-libiconv==${ICONV_VERSION} icu-dev jq libgcrypt-dev libcrypto1.1 libjpeg-turbo-dev \
+    gnu-libiconv==${ICONV_VERSION} icu-dev icu-data-full jq libgcrypt-dev libcrypto1.1 libjpeg-turbo-dev \
     libmcrypt-dev libmemcached-dev libpng-dev libssh2-dev libssl1.1 libxml2-dev libxslt-dev libzip-dev linux-headers make \
     musl-dev==${MUSL_VERSION} mysql-client openssh-client patch postgresql-client postgresql-dev rsync tzdata && \
     # Install Modd"

--- a/php/test.php
+++ b/php/test.php
@@ -74,6 +74,7 @@ EOF
 
         $this->logger->info(sprintf('> PHP version: %s', PHP_VERSION));
 
+        $this->checkI18n();
         $this->checkExtensions();
         $this->checkIniConfig();
 
@@ -86,6 +87,36 @@ EOF
         }
 
         return $this->exitStatus;
+    }
+
+    private function checkI18n(): void
+    {
+        $this->logger->info('> Locale functionality: ', false);
+
+        $errors    = [];
+        $testCases = [
+            ['expected' => 'Français (France)', 'locale' => 'fr-FR', 'displayLocale' => 'fr'],
+            ['expected' => 'French (France)', 'locale' => 'fr-FR', 'displayLocale' => 'en'],
+            ['expected' => 'Französisch (Frankreich)', 'locale' => 'fr-FR', 'displayLocale' => 'de'],
+        ];
+
+        foreach ($testCases as $testCase) {
+            $translation = ucfirst(\Locale::getDisplayName($testCase['locale'], $testCase['displayLocale']));
+
+            if ($testCase['expected'] === $translation) {
+                continue;
+            }
+
+            $errors[] = sprintf('Expected: "%s" => Given: "%s"', $testCase['expected'], $translation);
+        }
+
+        if ($errors) {
+            $this->logger->failure(sprintf("\n%s", implode("\n", $errors)));
+
+            ++$this->exitStatus;
+        } else {
+            $this->logger->success('Locale functionality validated!');
+        }
     }
 
     /**


### PR DESCRIPTION
**Update PHP images**

Handle translation issues.

- Add the **icu-data-full** package into the PHP images
- Remove the useless **gettext** extension and gettext-dev package from PHP 8.1

**Before**

<img width="848" alt="Capture d’écran 2024-05-28 à 15 51 23" src="https://github.com/ekino/docker-buildbox/assets/26876221/4e6ad763-389e-4131-b3e3-0eb2ec39d12c">

**After**

<img width="855" alt="Capture d’écran 2024-05-28 à 15 53 46" src="https://github.com/ekino/docker-buildbox/assets/26876221/c6a6627f-e409-4412-b5f5-68b2f1e27831">
