### PR TITLE
Azure: installing zip to use tfenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Versions
 
 2024-11-30
 ----------
+* Azure: installing zip to use tfenv
 * Node : adding 22.x.x image. Updating tooling
 
 2024-10-31

--- a/azure/Dockerfile
+++ b/azure/Dockerfile
@@ -32,7 +32,7 @@ ARG JQ_ARCH="arm64"
 
 FROM base-$TARGETARCH
 
-RUN apt-get update -qq && apt-get install -qq -y curl git gcc jq wget\
+RUN apt-get update -qq && apt-get install -qq -y curl git gcc zip jq wget\
     && pip install -U pip \
     && pip install pipenv azure-cli \
     && apt-get remove -y gcc && apt-get -qq -y autoremove \

--- a/azure/config.yml
+++ b/azure/config.yml
@@ -24,3 +24,5 @@ versions:
         - terragrunt --version
         - infracost --version
         - tfenv init
+        - unzip -v
+        - zip --version


### PR DESCRIPTION
Using `ekino/ci-azure:2-2024.10.31`:
```bash
$ tfenv install
Installing Terraform v1.9.8
Downloading release tarball from https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_linux_amd64.zip
######################################################################## 100.0%
Downloading SHA hash file from https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_SHA256SUMS
Not instructed to use Local PGP (/root/.tfenv/use-{gpgv,gnupg}) & No keybase install found, skipping OpenPGP signature verification
/root/.tfenv/libexec/tfenv-install: line 297: unzip: command not found
Tarball unzip failed
```