### PR TITLE
fix(gcp): use google-cloud-cli-gke-gcloud-auth-plugin package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Versions
 ========
 
+2026-08-31
+----------
+* GCP: fixing build by switching to the google-cloud-cli-gke-gcloud-auth-plugin package, the legacy google-cloud-sdk-* names having been removed upstream
+
 2026-07-31
 ----------
 * DIND: adding cosign, crane and syft

--- a/gcp/Dockerfile
+++ b/gcp/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update -qq && apt-get install -qq -y apt-transport-https ca-certific
     && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
     && apt-get update -qq \
-    && apt-get install -qq -y google-cloud-cli google-cloud-sdk-gke-gcloud-auth-plugin \
+    && apt-get install -qq -y google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin \
     && apt-get -qq -y autoremove \
     && apt-get -qq -y clean && apt-get -y -qq purge \
     && rm -rf /var/lib/apt/lists/* /var/lib/dpkg/*-old \


### PR DESCRIPTION
## Problem

Every `gcp` image build is failing, on master and on all open PRs (e.g. #1998). The `apt-get install` step in `gcp/Dockerfile` exits with code 100:

```
E: Package 'google-cloud-sdk-gke-gcloud-auth-plugin' has no installation candidate
```

Google has removed the legacy `google-cloud-sdk-*` transitional package names from their apt repository. Checking the current repo index confirms only the `google-cloud-cli-*` names remain:

```console
$ curl -sL https://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-amd64/Packages \
    | grep -E '^Package: google-cloud-(cli|sdk)' | sort -u
Package: google-cloud-cli
Package: google-cloud-cli-gke-gcloud-auth-plugin
```

Note that `google-cloud-cli` on the same line still resolves fine — only the `-sdk-` prefixed plugin is gone.

## Fix

Rename the package to `google-cloud-cli-gke-gcloud-auth-plugin`.

The repo suite is still named `cloud-sdk` and the sources-list filename is cosmetic, so lines 27–28 are left untouched.

## Notes

This is unrelated to any dependency bump — the last master run of *Build and test images* (`33053434109`, 2026-08-27) failed the same way. Once this lands, #1998 and other open PRs need a re-run.
