### PR TITLE
refactor: resolve tool versions in the build script, not in the images

### DIFF
--- a/.github/workflows/build-checker.yml
+++ b/.github/workflows/build-checker.yml
@@ -12,6 +12,11 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-24.04
+    # Only polls the commit's combined status and check runs - all read-only.
+    permissions:
+      contents: read
+      statuses: read
+      checks: read
     steps:
       - name: Wait for commit statuses
         id: status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ jobs:
 
   generate_matrix:
     runs-on: ubuntu-24.04
+    # Only needs to read the repository to diff it.
+    permissions:
+      contents: read
     if: github.actor != 'dependabot[bot]' || github.event_name == 'pull_request'
 
     steps:
@@ -42,6 +45,11 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
+    # GITHUB_TOKEN is used to log in to ghcr.io and push, so keep it to the
+    # minimum this job actually needs.
+    permissions:
+      contents: read
+      packages: write
     if: (github.actor != 'dependabot[bot]' || github.event_name == 'pull_request') && fromJSON(needs.generate_matrix.outputs.matrix).include[0]
     needs: generate_matrix
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,10 +69,26 @@ jobs:
         run: |
           pip install pip pipenv
           pipenv sync
+      # image_builder.py resolves tool versions from the GitHub API, which allows
+      # only 60 requests/hour unauthenticated. This token lifts that to
+      # 5000/hour and is deliberately not GITHUB_TOKEN: it grants nothing beyond
+      # reading public metadata, expires within the hour, and the action revokes
+      # it once the job ends.
+      - name: Mint a scoped token for the GitHub API version lookups
+        id: gh_api_token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-metadata: read
       - name: Build and tests images
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          # Used to log in to ghcr.io and push, nothing else.
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          # Read by src/version_resolver.py. It never reaches the builds, so
+          # nothing running inside an image can see it.
+          GH_AUTH_HEADER: "Authorization: Bearer ${{ steps.gh_api_token.outputs.token }}"
         run: |
           pipenv run python image_builder.py build -d --image ${{ matrix.image }} --version ${{ matrix.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Versions
 2026-09-30
 ----------
 * AWS, Azure, DIND, GCP, Golang, Node, Scaleway, Sonar & Upsun: tool version lookups now fail fast with an explicit error when the GitHub API is unavailable or rate-limited, instead of silently resolving to an empty version and downloading a 404 page. Remote lookups and downloads also retry on transient errors
+* AWS, Azure, DIND, GCP, Golang, Node, Scaleway, Sonar & Upsun: tool versions are now resolved by the build script and passed as build args, instead of being looked up from inside the image. The lookups are authenticated when a token is available, raising the rate limit from 60 to at least 5000 requests/hour and removing the intermittent 403 build failures, and they now happen once per build instead of once per architecture. Both architectures and the pushed image are built from the same versions, those versions are visible in the image history, and no credential is present while the image builds
+* AWS, Azure, GCP & Scaleway: Helm is no longer a release candidate. The 3.x lookup matched any tag containing v3.x.y, so a published v3.x.y-rc.N was picked ahead of the newest stable release
 * AWS, Chrome, DIND, Golang, Node, PHP & Scaleway: fixing the mime.types source, the Debian mime-support repository having been renamed to media-types. The old URL had been returning 404 for a while, and its HTML error page was being written to /etc/mime.types
 
 2026-08-31

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,12 +64,37 @@ test_config: &test_config
     - "tool --version"
 build_args: &build_args  # Optional: Docker build arguments
   TOOL_VERSION: "1.2.3"
+github_versions: &github_versions  # Optional: versions resolved from the GitHub API
+  TOOL_VERSION: owner/repo  # latest release, without its leading v
+  OTHER_VERSION:
+    repo: owner/repo
+    rule: latest  # or latest_tag, kustomize, latest_v3, highest_with_prefix
 versions:
   "version_name":
     platforms: *platforms
     build_args: *build_args
+    github_versions: *github_versions
     test_config: *test_config
 ```
+
+### Resolving tool versions
+`image_builder.py` resolves every `github_versions` entry before building and
+passes the results as build args, so the Dockerfiles never call the GitHub API
+themselves. Each entry needs a matching `ARG NAME` in the Dockerfile. Resolution
+rules live in `src/version_resolver.py`:
+
+| rule | picks |
+| --- | --- |
+| `latest` (default) | the latest release, minus a leading `v` |
+| `latest_tag` | the latest release tag verbatim |
+| `kustomize` | the latest `kustomize/vX.Y.Z` tag |
+| `latest_v3` | the newest stable `v3.x.y` release |
+| `highest_with_prefix` | the highest release tagged `<image version>.*` |
+
+Set `GH_AUTH_HEADER` (CI does, from a scoped GitHub App token) to get the
+authenticated rate limit; without it resolution still works, anonymously.
+Because the versions arrive as build args, a bare `docker build` fails with
+`NAME: must be passed as a build arg` - build through `image_builder.py`.
 
 ### CI/CD Matrix Logic
 The build system intelligently determines which images to build:

--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -25,6 +25,13 @@ ARG JQ_ARCH="arm64"
 FROM base-$TARGETARCH
 ARG AWSCLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip"
 
+# Tool versions, resolved from the GitHub API by image_builder.py
+ARG HELM_DIFF_VERSION
+ARG HELM_VERSION
+ARG INFRACOST_VERSION
+ARG KUSTOMIZE_VERSION
+ARG TERRAGRUNT_VERSION
+ARG TRIVY_VERSION
 RUN apt-get update -qq && apt-get install -qq -y curl git zip jq wget && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && apt-get -qq purge && \
@@ -45,38 +52,32 @@ RUN apt-get update -qq && apt-get install -qq -y curl git zip jq wget && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl && \
     # Downloading latest kustomize
-    KUSTOMIZE_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest | grep '"tag_name":' | sed -E 's/.*"kustomize\/v([^"]+)".*/\1/') && \
-    : "${KUSTOMIZE_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${KUSTOMIZE_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz && \
     tar -xf kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz && \
     rm kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz && \
     mv ./kustomize /usr/bin/kustomize && \
     # Downloading latest helm (3.x.x)
-    HELM_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/helm/helm/releases | grep '"tag_name":' | grep -E 'v3\.[0-9]+\.[0-9]+' | head -1 | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${HELM_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${HELM_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://get.helm.sh/helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz && \
     tar xf helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz && rm helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz && \
     mv ${HELM_ARCH}/helm /usr/local/bin/helm && \
     # Downloading latest helm diff plugin
-    HELM_DIFF_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/databus23/helm-diff/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${HELM_DIFF_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${HELM_DIFF_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     helm plugin install --version $HELM_DIFF_VERSION https://github.com/databus23/helm-diff && \
     # Downloading latest trivy
-    TRIVY_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/aquasecurity/trivy/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${TRIVY_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${TRIVY_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     tar xf trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     rm trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     mv trivy /usr/bin/trivy && \
     # Downloading latest terragrunt
-    TERRAGRUNT_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${TERRAGRUNT_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${TERRAGRUNT_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${TERRAGRUNT_ARCH} && \
     mv terragrunt_linux_${TERRAGRUNT_ARCH} /usr/bin/terragrunt && \
     chmod +x /usr/bin/terragrunt && \
     # Downloading latest infracost
-    INFRACOST_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/infracost/infracost/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${INFRACOST_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${INFRACOST_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-${INFRACOST_ARCH}.tar.gz && \
     tar xvf infracost-linux-${INFRACOST_ARCH}.tar.gz && \
     mv infracost-linux-${INFRACOST_ARCH} /usr/bin/infracost && \

--- a/aws/config.yml
+++ b/aws/config.yml
@@ -3,6 +3,17 @@ versions:
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions:
+      HELM_DIFF_VERSION: databus23/helm-diff
+      HELM_VERSION:
+        repo: helm/helm
+        rule: latest_v3
+      INFRACOST_VERSION: infracost/infracost
+      KUSTOMIZE_VERSION:
+        repo: kubernetes-sigs/kustomize
+        rule: kustomize
+      TERRAGRUNT_VERSION: gruntwork-io/terragrunt
+      TRIVY_VERSION: aquasecurity/trivy
     test_config:
       cmd:
         - aws --version

--- a/azure/Dockerfile
+++ b/azure/Dockerfile
@@ -25,6 +25,13 @@ ARG JQ_ARCH="arm64"
 
 FROM base-$TARGETARCH
 
+# Tool versions, resolved from the GitHub API by image_builder.py
+ARG HELM_DIFF_VERSION
+ARG HELM_VERSION
+ARG INFRACOST_VERSION
+ARG KUSTOMIZE_VERSION
+ARG TERRAGRUNT_VERSION
+ARG TRIVY_VERSION
 RUN apt-get update -qq && apt-get install -qq -y curl git gcc zip jq wget\
     && pip install -U pip \
     && pip install pipenv azure-cli \
@@ -38,38 +45,32 @@ RUN apt-get update -qq && apt-get install -qq -y curl git gcc zip jq wget\
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl && \
     # Downloading latest kustomize
-    KUSTOMIZE_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest | grep '"tag_name":' | sed -E 's/.*"kustomize\/v([^"]+)".*/\1/') && \
-    : "${KUSTOMIZE_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${KUSTOMIZE_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz && \
     tar -xf kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz && \
     rm kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz && \
     mv ./kustomize /usr/bin/kustomize && \
     # Downloading latest helm (3.x.x)
-    HELM_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/helm/helm/releases | grep '"tag_name":' | grep -E 'v3\.[0-9]+\.[0-9]+' | head -1 | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${HELM_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${HELM_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://get.helm.sh/helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz && \
     tar xf helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz && rm helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz && \
     mv ${HELM_ARCH}/helm /usr/local/bin/helm && \
     # Downloading latest helm diff plugin
-    HELM_DIFF_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/databus23/helm-diff/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${HELM_DIFF_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${HELM_DIFF_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     helm plugin install --version $HELM_DIFF_VERSION https://github.com/databus23/helm-diff && \
     # Downloading latest trivy
-    TRIVY_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/aquasecurity/trivy/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${TRIVY_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${TRIVY_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     tar xf trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     rm trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     mv trivy /usr/bin/trivy && \
     # Downloading latest terragrunt
-    TERRAGRUNT_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${TERRAGRUNT_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${TERRAGRUNT_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${TERRAGRUNT_ARCH} && \
     mv terragrunt_linux_${TERRAGRUNT_ARCH} /usr/bin/terragrunt && \
     chmod +x /usr/bin/terragrunt && \
     # Downloading latest infracost
-    INFRACOST_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/infracost/infracost/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${INFRACOST_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${INFRACOST_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-${INFRACOST_ARCH}.tar.gz && \
     tar xvf infracost-linux-${INFRACOST_ARCH}.tar.gz && \
     mv infracost-linux-${INFRACOST_ARCH} /usr/bin/infracost && \

--- a/azure/config.yml
+++ b/azure/config.yml
@@ -3,6 +3,17 @@ versions:
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions:
+      HELM_DIFF_VERSION: databus23/helm-diff
+      HELM_VERSION:
+        repo: helm/helm
+        rule: latest_v3
+      INFRACOST_VERSION: infracost/infracost
+      KUSTOMIZE_VERSION:
+        repo: kubernetes-sigs/kustomize
+        rule: kustomize
+      TERRAGRUNT_VERSION: gruntwork-io/terragrunt
+      TRIVY_VERSION: aquasecurity/trivy
     test_config:
       cmd:
         - az --version

--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -31,6 +31,11 @@ RUN echo "Install AWS & Azure CLIs" && \
 
 FROM base-$TARGETARCH
 ARG TARGETARCH
+# Tool versions, resolved from the GitHub API by image_builder.py
+ARG COSIGN_VERSION
+ARG CRANE_VERSION
+ARG SYFT_VERSION
+ARG TRIVY_VERSION
 RUN echo "Install Taskfile" && \
     sh -c "$(curl -f --location https://taskfile.dev/install.sh)" -- -d && \
     echo "Done Install Taskfile" && \
@@ -39,31 +44,27 @@ RUN echo "Install Taskfile" && \
     echo "Done install Docker Compose" && \
     echo "Install Trivy" && \
     # Downloading latest trivy
-    TRIVY_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/aquasecurity/trivy/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${TRIVY_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${TRIVY_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     tar xf trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     rm trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     mv trivy /usr/bin/trivy && \
     echo "Done install Trivy" && \
     echo "Install Cosign" && \
-    COSIGN_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/sigstore/cosign/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${COSIGN_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${COSIGN_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -f --retry 3 --retry-delay 2 -Lo /usr/bin/cosign https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-${TARGETARCH} && \
     chmod +x /usr/bin/cosign && \
     echo "Done install Cosign" && \
     echo "Install Crane" && \
     CRANE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x86_64") && \
-    CRANE_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/google/go-containerregistry/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${CRANE_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${CRANE_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz && \
     tar xf go-containerregistry_Linux_${CRANE_ARCH}.tar.gz crane && \
     rm go-containerregistry_Linux_${CRANE_ARCH}.tar.gz && \
     mv crane /usr/bin/crane && \
     echo "Done install Crane" && \
     echo "Install Syft" && \
-    SYFT_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/anchore/syft/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${SYFT_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${SYFT_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${TARGETARCH}.tar.gz && \
     tar xf syft_${SYFT_VERSION}_linux_${TARGETARCH}.tar.gz syft && \
     rm syft_${SYFT_VERSION}_linux_${TARGETARCH}.tar.gz && \

--- a/dind/config.yml
+++ b/dind/config.yml
@@ -3,6 +3,11 @@ versions:
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions:
+      COSIGN_VERSION: sigstore/cosign
+      CRANE_VERSION: google/go-containerregistry
+      SYFT_VERSION: anchore/syft
+      TRIVY_VERSION: aquasecurity/trivy
     test_config:
       cmd:
         - aws --version

--- a/gcp/Dockerfile
+++ b/gcp/Dockerfile
@@ -23,6 +23,13 @@ ARG JQ_ARCH="arm64"
 
 FROM base-$TARGETARCH
 
+# Tool versions, resolved from the GitHub API by image_builder.py
+ARG HELM_DIFF_VERSION
+ARG HELM_VERSION
+ARG INFRACOST_VERSION
+ARG KUSTOMIZE_VERSION
+ARG TERRAGRUNT_VERSION
+ARG TRIVY_VERSION
 RUN apt-get update -qq && apt-get install -qq -y apt-transport-https ca-certificates gnupg curl git zip unzip jq wget \
     && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
@@ -40,38 +47,32 @@ RUN apt-get update -qq && apt-get install -qq -y apt-transport-https ca-certific
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/bin/kubectl \
     # Downloading latest kustomize
-    && KUSTOMIZE_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest | grep '"tag_name":' | sed -E 's/.*"kustomize\/v([^"]+)".*/\1/') \
-    && : "${KUSTOMIZE_VERSION:?could not be resolved from the GitHub API}" \
+    && : "${KUSTOMIZE_VERSION:?must be passed as a build arg, resolved by image_builder.py}" \
     && curl -fLO --retry 3 --retry-delay 2 https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz \
     && tar -xf kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz \
     && rm kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz \
     && mv ./kustomize /usr/bin/kustomize \
     # Downloading latest trivy
-    && TRIVY_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/aquasecurity/trivy/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') \
-    && : "${TRIVY_VERSION:?could not be resolved from the GitHub API}" \
+    && : "${TRIVY_VERSION:?must be passed as a build arg, resolved by image_builder.py}" \
     && curl -fLO --retry 3 --retry-delay 2 https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz \
     && tar xf trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz \
     && rm trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz \
     && mv trivy /usr/bin/trivy \
     # Downloading latest helm (3.x.x)
-    && HELM_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/helm/helm/releases | grep '"tag_name":' | grep -E 'v3\.[0-9]+\.[0-9]+' | head -1 | sed -E 's/.*"v([^"]+)".*/\1/') \
-    && : "${HELM_VERSION:?could not be resolved from the GitHub API}" \
+    && : "${HELM_VERSION:?must be passed as a build arg, resolved by image_builder.py}" \
     && curl -fLO --retry 3 --retry-delay 2 https://get.helm.sh/helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz \
     && tar xf helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz && rm helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz \
     && mv ${HELM_ARCH}/helm /usr/local/bin/helm \
     # Downloading latest helm diff plugin
-    && HELM_DIFF_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/databus23/helm-diff/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') \
-    && : "${HELM_DIFF_VERSION:?could not be resolved from the GitHub API}" \
+    && : "${HELM_DIFF_VERSION:?must be passed as a build arg, resolved by image_builder.py}" \
     && helm plugin install --version $HELM_DIFF_VERSION https://github.com/databus23/helm-diff \
     # Downloading latest terragrunt
-    && TERRAGRUNT_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') \
-    && : "${TERRAGRUNT_VERSION:?could not be resolved from the GitHub API}" \
+    && : "${TERRAGRUNT_VERSION:?must be passed as a build arg, resolved by image_builder.py}" \
     && curl -fLO --retry 3 --retry-delay 2 https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${TERRAGRUNT_ARCH} \
     && mv terragrunt_linux_${TERRAGRUNT_ARCH} /usr/bin/terragrunt \
     && chmod +x /usr/bin/terragrunt \
     # Downloading latest infracost
-    && INFRACOST_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/infracost/infracost/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') \
-    && : "${INFRACOST_VERSION:?could not be resolved from the GitHub API}" \
+    && : "${INFRACOST_VERSION:?must be passed as a build arg, resolved by image_builder.py}" \
     && curl -fLO --retry 3 --retry-delay 2 https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-${INFRACOST_ARCH}.tar.gz \
     && tar xvf infracost-linux-${INFRACOST_ARCH}.tar.gz \
     && mv infracost-linux-${INFRACOST_ARCH} /usr/bin/infracost \

--- a/gcp/config.yml
+++ b/gcp/config.yml
@@ -3,6 +3,17 @@ versions:
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions:
+      HELM_DIFF_VERSION: databus23/helm-diff
+      HELM_VERSION:
+        repo: helm/helm
+        rule: latest_v3
+      INFRACOST_VERSION: infracost/infracost
+      KUSTOMIZE_VERSION:
+        repo: kubernetes-sigs/kustomize
+        rule: kustomize
+      TERRAGRUNT_VERSION: gruntwork-io/terragrunt
+      TRIVY_VERSION: aquasecurity/trivy
     test_config:
       cmd:
         - gcloud --version

--- a/golang/1.25/Dockerfile
+++ b/golang/1.25/Dockerfile
@@ -30,6 +30,13 @@ ARG MOCKGEN_ARCH="linux_arm64"
 FROM base-$TARGETARCH
 
 # Install packages
+# Tool versions, resolved from the GitHub API by image_builder.py
+ARG GITLEAKS_VERSION
+ARG GOLANGCILINT_VERSION
+ARG GOMODUPGRADE_VERSION
+ARG GOSWAGGER_VERSION
+ARG MIGRATE_VERSION
+ARG MOCKGEN_VERSION
 RUN apt-get update -q && \
     apt-get -qq -y install rsync zip curl unzip wget jq && \
     # Install AWS CLI
@@ -41,37 +48,31 @@ RUN apt-get update -q && \
     # Add an up to date mime-types definition file
     curl -fsSL --retry 3 --retry-delay 2 https://salsa.debian.org/debian/media-types/raw/master/mime.types -o /etc/mime.types && \
     # Install gitleaks
-    GITLEAKS_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${GITLEAKS_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${GITLEAKS_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${GITLEAKS_ARCH}.tar.gz && \
     tar -xzf gitleaks_${GITLEAKS_VERSION}_${GITLEAKS_ARCH}.tar.gz && \
     mv gitleaks /usr/local/bin && \
     # Install golangci-lint
-    GOLANGCILINT_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/golangci/golangci-lint/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${GOLANGCILINT_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${GOLANGCILINT_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCILINT_VERSION}/golangci-lint-${GOLANGCILINT_VERSION}-${GOLANGCILINT_ARCH}.tar.gz && \
     tar -xzf golangci-lint-${GOLANGCILINT_VERSION}-${GOLANGCILINT_ARCH}.tar.gz && \
     mv golangci-lint-${GOLANGCILINT_VERSION}-${GOLANGCILINT_ARCH}/golangci-lint /usr/local/bin && \
     rm -rf golangci-lint* && \
     # Install go-mod-upgrade
-    GOMODUPGRADE_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/oligot/go-mod-upgrade/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${GOMODUPGRADE_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${GOMODUPGRADE_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/oligot/go-mod-upgrade/releases/download/v${GOMODUPGRADE_VERSION}/go-mod-upgrade_${GOMODUPGRADE_ARCH}.tar.gz && \
     tar -xzf go-mod-upgrade_${GOMODUPGRADE_ARCH}.tar.gz -C /usr/local/bin && rm go-mod-upgrade* && \
     # Install go-swagger
-    GOSWAGGER_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/go-swagger/go-swagger/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${GOSWAGGER_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${GOSWAGGER_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/go-swagger/go-swagger/releases/download/v${GOSWAGGER_VERSION}/swagger_${GOSWAGGER_ARCH} && \
     mv swagger_${GOSWAGGER_ARCH} /usr/local/bin/swagger && chmod +x /usr/local/bin/swagger && \
     # Install migrate
-    MIGRATE_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/golang-migrate/migrate/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${MIGRATE_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${MIGRATE_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/golang-migrate/migrate/releases/download/v${MIGRATE_VERSION}/migrate.${GOMIGRATE_ARCH}.tar.gz && \
     tar -xzf migrate.${GOMIGRATE_ARCH}.tar.gz -C /usr/local/bin && \
     rm migrate.${GOMIGRATE_ARCH}.tar.gz && \
     # Install mockgen
-    MOCKGEN_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/golang/mock/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${MOCKGEN_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${MOCKGEN_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/golang/mock/releases/download/v${MOCKGEN_VERSION}/mock_${MOCKGEN_VERSION}_${MOCKGEN_ARCH}.tar.gz && \
     tar -xzf mock_${MOCKGEN_VERSION}_${MOCKGEN_ARCH}.tar.gz && \
     mv mock_${MOCKGEN_VERSION}_${MOCKGEN_ARCH}/mockgen /usr/local/bin && \

--- a/golang/1.26/Dockerfile
+++ b/golang/1.26/Dockerfile
@@ -30,6 +30,13 @@ ARG MOCKGEN_ARCH="linux_arm64"
 FROM base-$TARGETARCH
 
 # Install packages
+# Tool versions, resolved from the GitHub API by image_builder.py
+ARG GITLEAKS_VERSION
+ARG GOLANGCILINT_VERSION
+ARG GOMODUPGRADE_VERSION
+ARG GOSWAGGER_VERSION
+ARG MIGRATE_VERSION
+ARG MOCKGEN_VERSION
 RUN apt-get update -q && \
     apt-get -qq -y install rsync zip curl unzip wget jq && \
     # Install AWS CLI
@@ -41,37 +48,31 @@ RUN apt-get update -q && \
     # Add an up to date mime-types definition file
     curl -fsSL --retry 3 --retry-delay 2 https://salsa.debian.org/debian/media-types/raw/master/mime.types -o /etc/mime.types && \
     # Install gitleaks
-    GITLEAKS_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${GITLEAKS_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${GITLEAKS_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${GITLEAKS_ARCH}.tar.gz && \
     tar -xzf gitleaks_${GITLEAKS_VERSION}_${GITLEAKS_ARCH}.tar.gz && \
     mv gitleaks /usr/local/bin && \
     # Install golangci-lint
-    GOLANGCILINT_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/golangci/golangci-lint/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${GOLANGCILINT_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${GOLANGCILINT_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCILINT_VERSION}/golangci-lint-${GOLANGCILINT_VERSION}-${GOLANGCILINT_ARCH}.tar.gz && \
     tar -xzf golangci-lint-${GOLANGCILINT_VERSION}-${GOLANGCILINT_ARCH}.tar.gz && \
     mv golangci-lint-${GOLANGCILINT_VERSION}-${GOLANGCILINT_ARCH}/golangci-lint /usr/local/bin && \
     rm -rf golangci-lint* && \
     # Install go-mod-upgrade
-    GOMODUPGRADE_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/oligot/go-mod-upgrade/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${GOMODUPGRADE_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${GOMODUPGRADE_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/oligot/go-mod-upgrade/releases/download/v${GOMODUPGRADE_VERSION}/go-mod-upgrade_${GOMODUPGRADE_ARCH}.tar.gz && \
     tar -xzf go-mod-upgrade_${GOMODUPGRADE_ARCH}.tar.gz -C /usr/local/bin && rm go-mod-upgrade* && \
     # Install go-swagger
-    GOSWAGGER_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/go-swagger/go-swagger/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${GOSWAGGER_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${GOSWAGGER_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/go-swagger/go-swagger/releases/download/v${GOSWAGGER_VERSION}/swagger_${GOSWAGGER_ARCH} && \
     mv swagger_${GOSWAGGER_ARCH} /usr/local/bin/swagger && chmod +x /usr/local/bin/swagger && \
     # Install migrate
-    MIGRATE_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/golang-migrate/migrate/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${MIGRATE_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${MIGRATE_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/golang-migrate/migrate/releases/download/v${MIGRATE_VERSION}/migrate.${GOMIGRATE_ARCH}.tar.gz && \
     tar -xzf migrate.${GOMIGRATE_ARCH}.tar.gz -C /usr/local/bin && \
     rm migrate.${GOMIGRATE_ARCH}.tar.gz && \
     # Install mockgen
-    MOCKGEN_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/golang/mock/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${MOCKGEN_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${MOCKGEN_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     wget -q https://github.com/golang/mock/releases/download/v${MOCKGEN_VERSION}/mock_${MOCKGEN_VERSION}_${MOCKGEN_ARCH}.tar.gz && \
     tar -xzf mock_${MOCKGEN_VERSION}_${MOCKGEN_ARCH}.tar.gz && \
     mv mock_${MOCKGEN_VERSION}_${MOCKGEN_ARCH}/mockgen /usr/local/bin && \

--- a/golang/config.yml
+++ b/golang/config.yml
@@ -9,14 +9,24 @@ test_config: &test_config
     - rsync --version
     - swagger version
 
+github_versions: &github_versions
+  GITLEAKS_VERSION: gitleaks/gitleaks
+  GOLANGCILINT_VERSION: golangci/golangci-lint
+  GOMODUPGRADE_VERSION: oligot/go-mod-upgrade
+  GOSWAGGER_VERSION: go-swagger/go-swagger
+  MIGRATE_VERSION: golang-migrate/migrate
+  MOCKGEN_VERSION: golang/mock
+
 versions:
   "1.25":
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions: *github_versions
     test_config: *test_config
   "1.26":
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions: *github_versions
     test_config: *test_config

--- a/image_builder.py
+++ b/image_builder.py
@@ -5,6 +5,7 @@ from python_on_whales import docker
 
 import src.config as config
 import src.docker_tools as docker_tools
+import src.version_resolver as version_resolver
 
 
 @click.command()
@@ -29,6 +30,18 @@ def build(image, version, debug):
     # Set the subdirectory in path because we want dockerfile_directory (aka the build context) to be the parent image directory
     dockerfile_path = prefixed_dockerfile_path if exists(
         f"{dockerfile_directory}/{prefixed_dockerfile_path}") else "Dockerfile"
+
+    # Resolve the tool versions the Dockerfile expects as build args. Doing it
+    # here rather than inside the build means one request per tool instead of one
+    # per architecture, and pins the tested image and the pushed one to the same
+    # versions.
+    try:
+        image_conf["build_args"].update(
+            version_resolver.resolve(image_conf.get("github_versions") or {}, version)
+        )
+    except version_resolver.VersionResolutionError as e:
+        print(f"> [Error] {e}")
+        exit(1)
 
     # Build image tags list (base tag + archs)
     image_tags = config.get_image_tags(image, version, image_conf, env_conf)

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -16,6 +16,8 @@ FROM base AS base-arm64
 ARG AWSCLI_ARCH="linux-aarch64"
 
 FROM base-$TARGETARCH
+# Tool versions, resolved from the GitHub API by image_builder.py
+ARG LATEST_NVM_VERSION
 RUN echo "Starting ..." && \
     apt-get -qq clean && apt-get -qq update && \
     apt-get -qq -y install libssl-dev curl git imagemagick make gnupg \
@@ -27,9 +29,7 @@ RUN echo "Starting ..." && \
     sh -c "$(curl -f --location https://taskfile.dev/install.sh)" -- -d && \
     echo "Done Install Taskfile" && \
     echo "Starting Javascript..." && \
-    echo "Fetching latest NVM version..." && \
-    LATEST_NVM_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name // empty' | sed 's/^v//') && \
-    : "${LATEST_NVM_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${LATEST_NVM_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     echo "Using NVM version: ${LATEST_NVM_VERSION}" && \
     echo "Fetching latest Node.js version for major version ${VERSION}..." && \
     LATEST_NODE_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors "https://nodejs.org/dist/index.json" | jq -r --arg major "v${VERSION}." '[.[] | select(.version | startswith($major)) | .version] | .[0] // empty' | sed 's/^v//') && \

--- a/node/config.yml
+++ b/node/config.yml
@@ -7,19 +7,25 @@ test_config: &test_config
     - sass --version
     - task --version
 
+github_versions: &github_versions
+  LATEST_NVM_VERSION: nvm-sh/nvm
+
 versions:
   "22":
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions: *github_versions
     test_config: *test_config
   "24":
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions: *github_versions
     test_config: *test_config
   "26":
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions: *github_versions
     test_config: *test_config

--- a/scaleway/Dockerfile
+++ b/scaleway/Dockerfile
@@ -25,6 +25,13 @@ ARG SCW_ARCH="arm64"
 FROM base-$TARGETARCH
 ARG AWSCLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip"
 
+# Tool versions, resolved from the GitHub API by image_builder.py
+ARG HELM_DIFF_VERSION
+ARG HELM_VERSION
+ARG KUSTOMIZE_VERSION
+ARG SCW_VERSION
+ARG TERRAGRUNT_VERSION
+ARG TRIVY_VERSION
 RUN apt-get update -qq && apt-get install -qq -y curl git zip jq wget && \
     apt-get -qq -y autoremove && \
     apt-get -qq clean && apt-get -qq purge && \
@@ -37,8 +44,7 @@ RUN apt-get update -qq && apt-get install -qq -y curl git zip jq wget && \
     pip install -U pip && \
     pip install pipenv && \
     # Installing SCW Cli
-    SCW_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/scaleway/scaleway-cli/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${SCW_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${SCW_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/scaleway/scaleway-cli/releases/download/v${SCW_VERSION}/scaleway-cli_${SCW_VERSION}_linux_${SCW_ARCH} && \
     mv scaleway-cli_${SCW_VERSION}_linux_${SCW_ARCH} /usr/bin/scw && \
     chmod +x /usr/bin/scw && \
@@ -47,32 +53,27 @@ RUN apt-get update -qq && apt-get install -qq -y curl git zip jq wget && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl && \
     # Downloading latest kustomize
-    KUSTOMIZE_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest | grep '"tag_name":' | sed -E 's/.*"kustomize\/v([^"]+)".*/\1/') && \
-    : "${KUSTOMIZE_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${KUSTOMIZE_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz && \
     tar -xf kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz && \
     rm kustomize_v${KUSTOMIZE_VERSION}_${KUSTOMIZE_ARCH}.tar.gz && \
     mv ./kustomize /usr/bin/kustomize && \
     # Downloading latest helm (3.x.x)
-    HELM_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/helm/helm/releases | grep '"tag_name":' | grep -E 'v3\.[0-9]+\.[0-9]+' | head -1 | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${HELM_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${HELM_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://get.helm.sh/helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz && \
     tar xf helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz && rm helm-v${HELM_VERSION}-${HELM_ARCH}.tar.gz && \
     mv ${HELM_ARCH}/helm /usr/local/bin/helm && \
     # Downloading latest helm diff plugin
-    HELM_DIFF_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/databus23/helm-diff/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${HELM_DIFF_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${HELM_DIFF_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     helm plugin install --version $HELM_DIFF_VERSION https://github.com/databus23/helm-diff && \
     # Downloading latest trivy
-    TRIVY_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/aquasecurity/trivy/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${TRIVY_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${TRIVY_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     tar xf trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     rm trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
     mv trivy /usr/bin/trivy && \
     # Downloading latest terragrunt
-    TERRAGRUNT_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
-    : "${TERRAGRUNT_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${TERRAGRUNT_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     curl -fLO --retry 3 --retry-delay 2 https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${TERRAGRUNT_ARCH} && \
     mv terragrunt_linux_${TERRAGRUNT_ARCH} /usr/bin/terragrunt && \
     chmod +x /usr/bin/terragrunt && \

--- a/scaleway/config.yml
+++ b/scaleway/config.yml
@@ -3,6 +3,17 @@ versions:
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions:
+      HELM_DIFF_VERSION: databus23/helm-diff
+      HELM_VERSION:
+        repo: helm/helm
+        rule: latest_v3
+      KUSTOMIZE_VERSION:
+        repo: kubernetes-sigs/kustomize
+        rule: kustomize
+      SCW_VERSION: scaleway/scaleway-cli
+      TERRAGRUNT_VERSION: gruntwork-io/terragrunt
+      TRIVY_VERSION: aquasecurity/trivy
     test_config:
       cmd:
         - scw version

--- a/sonar/Dockerfile
+++ b/sonar/Dockerfile
@@ -7,15 +7,13 @@ ARG VERSION
 
 ENV PATH=${SONARSCANNER_HOME}/bin:${PATH}
 
+# Tool versions, resolved from the GitHub API by image_builder.py
+ARG SONARSCANNER_VERSION
 RUN echo "Starting ..." && \
     apk --update upgrade && apk add curl gcompat make tzdata unzip openjdk21-jre jq && \
     echo "Done base install!" && \
     echo "Starting Sonar Scanner" && \
-    echo "Fetching latest version for major version ${VERSION}..." && \
-    SONARSCANNER_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/SonarSource/sonar-scanner-cli/releases | \
-        jq -r --arg major "${VERSION}" \
-        '[.[] | select(.tag_name | startswith($major)) | .tag_name] | sort_by(. | split(".") | map(tonumber)) | last // empty') && \
-    : "${SONARSCANNER_VERSION:?could not be resolved from the GitHub API}" && \
+    : "${SONARSCANNER_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
     echo "Using SonarScanner version: ${SONARSCANNER_VERSION}" && \
     curl -f --retry 3 --retry-delay 2 -o ./sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONARSCANNER_VERSION}.zip && \
     unzip sonarscanner.zip && \

--- a/sonar/config.yml
+++ b/sonar/config.yml
@@ -3,6 +3,10 @@ versions:
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions:
+      SONARSCANNER_VERSION:
+        repo: SonarSource/sonar-scanner-cli
+        rule: highest_with_prefix
     test_config:
       cmd:
         - java -version

--- a/src/version_resolver.py
+++ b/src/version_resolver.py
@@ -1,0 +1,206 @@
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+
+from src.docker_tools import retry_with_backoff
+
+API_ROOT = "https://api.github.com/repos"
+USER_AGENT = "ekino-docker-buildbox"
+
+
+class TransientApiError(Exception):
+    """A GitHub API failure worth retrying: timeout, 5xx, secondary rate limit."""
+
+
+class VersionResolutionError(Exception):
+    """A tool version could not be resolved, and retrying would not help."""
+
+
+class AuthRefused(VersionResolutionError):
+    """GitHub refused the authenticated request, but may still serve it anonymously."""
+
+
+def _auth_header():
+    """The Authorization header to send, as a (name, value) pair, or None.
+
+    CI provides GH_AUTH_HEADER because anonymous callers get only 60 requests
+    per hour, which a full matrix build used to exhaust. Local builds without it
+    simply stay anonymous. An empty token - what a fork pull request gets, since
+    secrets are not exposed to it - counts as no header at all, rather than
+    guaranteeing a 401.
+    """
+    header = os.environ.get("GH_AUTH_HEADER", "").strip()
+    name, _, value = header.partition(":")
+    value = value.strip()
+    if not name or value in ("", "Bearer", "token"):
+        return None
+    return name.strip(), value
+
+
+@retry_with_backoff(exceptions=(TransientApiError,))
+def _get(url, authenticated):
+    header = _auth_header() if authenticated else None
+    request = urllib.request.Request(url, headers={
+        "Accept": "application/vnd.github+json",
+        "User-Agent": USER_AGENT,
+    })
+    if header:
+        request.add_header(*header)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as http_error:
+        raise _explain(url, http_error, authenticated) from http_error
+    except (urllib.error.URLError, TimeoutError) as url_error:
+        raise TransientApiError(f"{url}: {url_error}") from url_error
+
+
+def _explain(url, http_error, authenticated):
+    """Turn an HTTP error into the exception that says what to do about it."""
+    mode = "authenticated" if authenticated else "anonymous"
+    context = f"{url} returned HTTP {http_error.code} ({mode} request)"
+
+    if http_error.code >= 500:
+        return TransientApiError(context)
+
+    if http_error.code in (403, 429):
+        # A secondary rate limit comes with the delay to honour, and going
+        # anonymous does not help - the limit is per caller, not per credential.
+        retry_after = http_error.headers.get("retry-after")
+        if retry_after:
+            return TransientApiError(f"{context} - secondary rate limit, retry-after {retry_after}s")
+
+        exhausted = http_error.headers.get("x-ratelimit-remaining") == "0"
+        reset = http_error.headers.get("x-ratelimit-reset")
+        detail = f" - rate limit exhausted, resets at {reset}" if exhausted else ""
+        if authenticated:
+            # Not necessarily a rate limit: some orgs (aquasecurity, for one)
+            # enable an IP allow list that refuses authenticated requests from CI
+            # runners while still serving the same public data anonymously. The
+            # anonymous quota is separate, so it is worth a try either way.
+            return AuthRefused(f"{context}{detail}")
+        return VersionResolutionError(f"{context}{detail}")
+
+    if http_error.code == 404:
+        return VersionResolutionError(
+            f"{context} - the repository was renamed or removed, or the token cannot see it"
+        )
+
+    return VersionResolutionError(context)
+
+
+def _fetch(path):
+    url = f"{API_ROOT}/{path}"
+    if _auth_header() is None:
+        return _get(url, authenticated=False)
+    try:
+        return _get(url, authenticated=True)
+    except AuthRefused as refused:
+        print(f"> [Warning] {refused} - retrying anonymously")
+        return _get(url, authenticated=False)
+
+
+def _latest_tag(repo):
+    tag = _fetch(f"{repo}/releases/latest").get("tag_name", "")
+    if not tag:
+        raise VersionResolutionError(f"{repo}: the latest release has no tag_name")
+    return tag
+
+
+def _released_tags(repo):
+    releases = _fetch(f"{repo}/releases?per_page=100")
+    return [
+        release.get("tag_name", "") for release in releases
+        if not release.get("prerelease") and not release.get("draft")
+    ]
+
+
+def _strip_prefix(repo, tag, pattern):
+    match = re.match(pattern, tag)
+    if not match:
+        raise VersionResolutionError(f"{repo}: tag {tag!r} does not match {pattern!r}")
+    return match.group(1)
+
+
+def _latest(repo, image_version):
+    """The latest release, without its leading v: v1.2.3 -> 1.2.3."""
+    return _strip_prefix(repo, _latest_tag(repo), r"^v?(.+)$")
+
+
+def _latest_tag_as_is(repo, image_version):
+    """The latest release tag verbatim, for projects that tag without a v."""
+    return _latest_tag(repo)
+
+
+def _kustomize(repo, image_version):
+    """Kustomize shares a repository with other tools and tags kustomize/vX.Y.Z."""
+    return _strip_prefix(repo, _latest_tag(repo), r"^kustomize/v(.+)$")
+
+
+def _latest_v3(repo, image_version):
+    """The latest 3.x.y release, for Helm, whose 2.x line is still tagged."""
+    for tag in _released_tags(repo):
+        if re.match(r"^v3\.\d+\.\d+$", tag):
+            return tag[1:]
+    raise VersionResolutionError(f"{repo}: no v3.x.y release found")
+
+
+def _highest_with_prefix(repo, image_version):
+    """The highest release whose tag starts with the image version.
+
+    The Sonar scanner tags 8.1.0.1234, and the 8.1 image wants the newest of
+    those - which is not necessarily the newest release overall.
+    """
+    def parts(tag):
+        return [int(part) for part in tag.split(".")]
+
+    candidates = [
+        tag for tag in _released_tags(repo)
+        if tag.startswith(f"{image_version}.") and re.match(r"^[\d.]+$", tag)
+    ]
+    if not candidates:
+        raise VersionResolutionError(f"{repo}: no release tagged {image_version}.*")
+    return max(candidates, key=parts)
+
+
+RULES = {
+    "latest": _latest,
+    "latest_tag": _latest_tag_as_is,
+    "kustomize": _kustomize,
+    "latest_v3": _latest_v3,
+    "highest_with_prefix": _highest_with_prefix,
+}
+
+
+def _parse_spec(build_arg, spec):
+    """Read one github_versions entry: either 'owner/repo' or {repo:, rule:}."""
+    if isinstance(spec, str):
+        repo, rule = spec, "latest"
+    else:
+        repo, rule = spec.get("repo"), spec.get("rule", "latest")
+    if not repo:
+        raise VersionResolutionError(f"{build_arg}: no repo configured")
+    if rule not in RULES:
+        raise VersionResolutionError(
+            f"{build_arg}: unknown rule {rule!r} - known rules are {', '.join(sorted(RULES))}"
+        )
+    return repo, rule
+
+
+def resolve(github_versions, image_version):
+    """Resolve the tool versions a Dockerfile expects to be passed as build args.
+
+    The Dockerfiles used to do this themselves, once per architecture and once
+    per build, which meant a full matrix build spent 172 requests against a
+    60/hour anonymous limit and could tag the pushed image with different
+    versions than the tested one. Resolving here spends one request per tool and
+    pins both builds to the same answers.
+    """
+    build_args = {}
+    for build_arg, spec in sorted(github_versions.items()):
+        repo, rule = _parse_spec(build_arg, spec)
+        build_args[build_arg] = RULES[rule](repo, image_version)
+        print(f"> [Info] {build_arg}={build_args[build_arg]} (from {repo})")
+    return build_args

--- a/upsun/Dockerfile
+++ b/upsun/Dockerfile
@@ -11,11 +11,11 @@ FROM base AS base-arm64
 ARG CLI_ARCH="arm64"
 
 FROM base-$TARGETARCH
+# Tool versions, resolved from the GitHub API by image_builder.py
+ARG CLI_VERSION
 RUN apt-get update -qq && apt-get install -y curl git jq \
     && pip install pipenv \
-    && echo "Fetching latest version of Platform.sh and Upsun CLIs..." \
-    && CLI_VERSION=$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors https://api.github.com/repos/platformsh/cli/releases/latest | jq -r '.tag_name // empty') \
-    && : "${CLI_VERSION:?could not be resolved from the GitHub API}" \
+    && : "${CLI_VERSION:?must be passed as a build arg, resolved by image_builder.py}" \
     && echo "Using CLI version: ${CLI_VERSION}" \
     && curl -fsSL --retry 3 --retry-delay 2 "https://github.com/platformsh/cli/releases/download/${CLI_VERSION}/upsun-cli_${CLI_VERSION}_linux_${CLI_ARCH}.deb" -o /tmp/upsun.deb \
     && curl -fsSL --retry 3 --retry-delay 2 "https://github.com/platformsh/cli/releases/download/${CLI_VERSION}/platformsh-cli_${CLI_VERSION}_linux_${CLI_ARCH}.deb" -o /tmp/platform.deb \

--- a/upsun/config.yml
+++ b/upsun/config.yml
@@ -3,6 +3,10 @@ versions:
     platforms:
       - linux/amd64
       - linux/arm64
+    github_versions:
+      CLI_VERSION:
+        repo: platformsh/cli
+        rule: latest_tag
     test_config:
       cmd:
         - git --version


### PR DESCRIPTION
Follow-up to #2017. That PR made a failed version lookup *fail loudly*; this one stops most of them failing at all, by moving the lookups out of the images entirely.

## Problem

Every Dockerfile resolved the latest version of each tool it installs by querying `api.github.com` from inside its own build:

```
unauthenticated:   60 requests/hour
authenticated:   5000 requests/hour
```

Because the lookup runs inside the build, it runs **once per architecture**, and again for the pushed build — so a full matrix spends 90 requests on a PR and 180 on master, against a 60/hour budget. This is what took out `build (dind, 1)` on #2017:

```
2.654  Install Trivy
2.723  curl: (22) The requested URL returned error: 403   ← rate limited
8.785  /bin/sh: TRIVY_VERSION: could not be resolved from the GitHub API
```

## Approach

`image_builder.py` resolves the versions **before** the build and passes them as build args, the way the PHP images already take their tool versions. Each image declares what it needs in its `config.yml`:

```yaml
github_versions:
  TRIVY_VERSION: aquasecurity/trivy          # latest release, minus the leading v
  KUSTOMIZE_VERSION:
    repo: kubernetes-sigs/kustomize
    rule: kustomize                          # this repo tags kustomize/vX.Y.Z
```

and the Dockerfile just declares the arg:

```dockerfile
ARG TRIVY_VERSION
RUN : "${TRIVY_VERSION:?must be passed as a build arg, resolved by image_builder.py}" && \
    curl -fLO .../v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_ARCH}.tar.gz && \
```

Five rules in [`src/version_resolver.py`](src/version_resolver.py) cover all 45 lookups: `latest`, `latest_tag`, `kustomize`, `latest_v3`, `highest_with_prefix`.

### Why not just authenticate the curl calls?

That was this PR's first approach — a BuildKit secret holding the auth header, read by a small `gh_api` helper in each Dockerfile. It worked, but it has two problems the current shape doesn't:

- **The credential sits inside the image build.** These are single mega-`RUN` chains, so the token is readable at `/run/secrets/` for the whole build — including while `sh -c "$(curl https://taskfile.dev/install.sh)"`, `helm plugin install`, `pip install azure-cli` and `apt-get` run as root. A compromise upstream of any of those would have yielded a live credential.
- **The helper had to be copy-pasted ten times**, so the retry logic, the 403 handling and the parsing existed in ten places that had to change together.

Resolving in Python removes both: no credential is present while an image builds, and there is one implementation.

## What ships

| commit | |
|---|---|
| `ea6210c` | job-level `permissions:` on all three workflow jobs — they were inheriting the repository default of write-on-every-scope |
| `4b19dc2` | the resolver, the `github_versions` config, the Dockerfile changes |
| `10ab3ca` | a metadata-only GitHub App token for the lookups |

The token is deliberately **not** `GITHUB_TOKEN`, which can publish to ghcr.io. `actions/create-github-app-token` with `permission-metadata: read` grants nothing beyond reading public metadata, expires within the hour, and is revoked when the job ends. (It also reuses the `APP_ID`/`APP_PRIVATE_KEY` secrets already in the repo for `claude-app.yml`, so there is no new secret to manage.)

## A bug this uncovered

The Helm 3.x lookup was:

```sh
grep '"tag_name":' | grep -E 'v3\.[0-9]+\.[0-9]+' | head -1
```

The pattern is unanchored, so a prerelease matches it — and `/releases` returns newest first:

```
what the current pipeline picks:  3.22.0-rc.1
https://get.helm.sh/helm-v3.22.0-rc.1-linux-amd64.tar.gz  →  200
what the resolver picks:          3.21.4   (newest stable v3.x.y)
```

`get.helm.sh` serves RC tarballs, so the build succeeded and **aws, azure, gcp and scaleway have been shipping a release-candidate Helm**. The resolver filters prereleases and anchors the pattern.

## Numbers

| | before | after |
|---|---|---|
| requests, PR build | 90 | 45 |
| requests, master build | 180 | 45 |
| rate limit | 60/h | 5000/h |
| copies of the lookup logic | 10 | 1 |
| credential inside the image build | — (or the token, under the first approach) | none |

Resolving once also means **both architectures and the pushed image are built from the same versions**. Before, each build invocation resolved its own, so the image pushed to the registry was not necessarily built from the versions that were tested.

## Verification

- **All 45 lookups resolve against the live API** — the 19 distinct repo/rule pairs each return a version matching what the Dockerfile's download URL expects (`SONARSCANNER_VERSION=8.1.0.6389` for the 8.1 image, `CLI_VERSION=5.9.0` kept verbatim for upsun, and so on).
- **End-to-end through the real `build()`** with Docker stubbed out: `aws:1` reaches buildx with all six `--build-arg`s plus the existing `VERSION`, one `build_image` call, correct context and tag.
- **Parity check across the matrix**: 45 declared lookups, 0 inconsistencies — every `github_versions` key has a matching `ARG` and a guard, and no guard is orphaned.
- **Shell syntax**: all 32 `RUN` blocks in the repo re-checked with `sh -n`, `dash -n`, `bash -n` (these images are Debian and Alpine, so `/bin/sh` is not bash).
- **Failure paths** exit with actionable messages: a 404 names a renamed repo or a token that cannot see it, an unknown rule lists the valid ones, and an empty `GH_AUTH_HEADER` — what a fork PR gets, since secrets are not exposed to it — is treated as no token rather than sent as a guaranteed 401.
- **CI**: the App token was validated on a full green matrix before the refactor landed, which confirmed that `permission-metadata: read` is enough to read releases of public repos outside the installation.

No `docker build` was run locally — Docker isn't available on this machine — so the Dockerfile edits are mechanical and syntax-checked rather than build-tested. CI is the proof.

## Notes

- A bare `docker build` now fails with `TRIVY_VERSION: must be passed as a build arg`. That's intentional; `CLAUDE.md` documents the schema, the rules and this caveat.
- The `nodejs.org` lookup in the node image stays where it is — it isn't GitHub and isn't rate-limited the same way.
- Some orgs (aquasecurity, for one) run an IP allow list that refuses authenticated requests from CI runners while still serving the same public data anonymously, so the resolver falls back to an anonymous request on a 403. Rate-limit and secondary-limit 403s are distinguished from that by their headers.
- #2017's `:?` guards remain the safety net for anything that still can't be resolved.
