### PR TITLE
ci: stop building every pull request twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,15 @@
 name: Build and test images
 
 on:
+  # push is limited to master on purpose. An unfiltered push trigger fired a
+  # second, identical run for every branch push that already had a pull request
+  # open - same matrix, same builds, nothing published either time - and fired a
+  # full run for tag pushes, which publish nothing because only the release
+  # event sets a tag. Use workflow_dispatch to build a branch with no pull
+  # request open.
   push:
+    branches:
+      - master
   pull_request:
     branches:
       - master
@@ -9,8 +17,11 @@ on:
     types: [published]
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 concurrency:
+  # event_name stays in the group: it keeps the nightly run from cancelling a
+  # master build, since both are refs/heads/master.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 


### PR DESCRIPTION
Every push to a branch with an open pull request started **two** full matrix runs — 56 jobs where 28 would do.

## Why

```yaml
on:
  push:            # ← no branch filter: every branch push, and every tag
  pull_request:
    branches: [master]

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
```

Both triggers fire for the same commit, and `event_name` in the concurrency group is exactly what stops one from cancelling the other.

## The two runs did identical work

Not merely similar — the same, which is checkable in the code rather than by eye:

| | |
|---|---|
| same matrix | [`matrix_generator.py`](matrix_generator.py#L22) always diffs `origin/master` against HEAD, whatever the event |
| same builds | [`image_builder.py`](image_builder.py#L47-L52) only publishes for a tag, a master push or the schedule — so a branch push builds to the throwaway local registry and tests, exactly like the `pull_request` run |
| same tags | in [`get_image_tags`](src/config.py#L81-L85) the `branch == master` arm and the `else` arm both yield `latest` |

## Change

```yaml
on:
  push:
    branches:
      - master
  pull_request:
    branches:
      - master
  release:
    types: [published]
  schedule:
    - cron: "0 0 * * *"
  workflow_dispatch:
```

| scenario | before | after |
|---|---|---|
| push to a branch with a PR open | 56 jobs | 28 |
| merge to master | 28 | 28 |
| tag pushed without a release | 28 jobs that publish nothing | 0 |
| branch with no PR open | 28 | 0, or on demand |
| pull request from a fork | 28 | 28 |

Limiting `push` to master also drops the run a **tag push** used to trigger. That one built all 28 images and published none of them, because `env_conf["tag"]` is only set for the `release` event — `release: published` is what actually publishes.

## Things deliberately left alone

- **`event_name` stays in the concurrency group.** It looks redundant once only one run fires per commit, but it stops a nightly run from cancelling an in-flight master build — both are `refs/heads/master`.
- **The master `push` run is kept**, so the README badge (`build.yml/badge.svg?branch=master`) still reports.
- **Fork pull requests are unaffected** — `push` never fired in this repository for them anyway.

## Tradeoff

A branch with no pull request open no longer builds. `workflow_dispatch` covers deliberate pre-PR testing, and a draft PR covers the rest.

## This PR verifies itself

Pushing the branch triggered **zero** runs, because GitHub reads `on:` from the pushed commit. Opening this PR uses the merge commit's `build.yml`, so `pull_request` fires — there should be exactly **one** "Build and test images" run below rather than two.

## Not in this PR

Every master merge, release and nightly still builds each image **twice**: `build()` builds to the local registry and tests it, then calls `build_image` again for Docker Hub and ghcr.io with `cache=False`. That is also why the published image is not the one that was tested. Copying the tested manifest instead — `docker.buildx.imagetools.create(sources=[local], tags=[...])`, which performs a carbon copy for a single source — would roughly halve publishing runs and make the published image provably the tested one. It touches the publish path, so it deserves its own PR.
