### PR TITLE
perf: publish the layers the tests ran against, not a second build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Versions
 
 2026-09-30
 ----------
+* All images: the image published to Docker Hub and GHCR is now built from the layers the tests ran against, instead of being rebuilt from scratch after testing. Publishing runs are correspondingly faster
 * AWS, Azure, DIND, GCP, Golang, Node, Scaleway, Sonar & Upsun: tool version lookups now fail fast with an explicit error when the GitHub API is unavailable or rate-limited, instead of silently resolving to an empty version and downloading a 404 page. Remote lookups and downloads also retry on transient errors
 * AWS, Azure, DIND, GCP, Golang, Node, Scaleway, Sonar & Upsun: tool versions are now resolved by the build script and passed as build args, instead of being looked up from inside the image. The lookups are authenticated when a token is available, raising the rate limit from 60 to at least 5000 requests/hour and removing the intermittent 403 build failures, and they now happen once per build instead of once per architecture. Both architectures and the pushed image are built from the same versions, those versions are visible in the image history, and no credential is present while the image builds
 * AWS, Azure, GCP & Scaleway: Helm is no longer a release candidate. The 3.x lookup matched any tag containing v3.x.y, so a published v3.x.y-rc.N was picked ahead of the newest stable release

--- a/image_builder.py
+++ b/image_builder.py
@@ -46,10 +46,11 @@ def build(image, version, debug):
     # Build image tags list (base tag + archs)
     image_tags = config.get_image_tags(image, version, image_conf, env_conf)
 
-    with docker_tools.start_local_registry() as local_registry:
+    with docker_tools.start_local_registry(), docker_tools.build_builder() as builder:
 
         # Build, tag and push docker image to local registry
-        docker_tools.build_image(image_conf, image_tags["localname"], dockerfile_directory, dockerfile_path, debug)
+        docker_tools.build_image(image_conf, image_tags["localname"], dockerfile_directory, dockerfile_path, debug,
+                                 builder)
 
         # Run defined test command
         docker_tools.run_image(image_tags["localname"], image_conf, debug)
@@ -70,7 +71,10 @@ def build(image, version, debug):
                 print(f"> [Error] Failed to login to registries after retries: {e}")
                 exit(1)
 
-            # Build, tag and push docker image to remote registry (Docker hub)
+            # Push to the remote registries (Docker Hub and GHCR). Reusing the
+            # builder above means every layer is a cache hit, so this publishes
+            # the layers the tests just ran against instead of building the
+            # image a second time.
             docker_tools.build_image(image_conf,
                                      [
                                          image_tags["docker_fullname"],
@@ -78,7 +82,9 @@ def build(image, version, debug):
                                      ],
                                      dockerfile_directory,
                                      dockerfile_path,
-                                     debug)
+                                     debug,
+                                     builder,
+                                     cache=True)
 
 
 @click.group()

--- a/src/docker_tools.py
+++ b/src/docker_tools.py
@@ -1,6 +1,7 @@
 import os
 import pprint
 import time
+from contextlib import contextmanager
 from functools import wraps
 
 from python_on_whales import docker
@@ -66,9 +67,30 @@ def retry_with_backoff(max_retries=None,
     return decorator
 
 
+@contextmanager
+def build_builder():
+    """A buildx builder shared by every build of one image.
+
+    A publishing run builds twice: once to the local registry, which is what the
+    tests run against, and once to the remote registries. Sharing the builder
+    lets the second build reuse the layers the first one produced instead of
+    building the image again from scratch. The builder, and its cache, is
+    destroyed with the job, so nothing stale can reach another build.
+    """
+    builder = docker.buildx.create(use=True, driver_options=dict(network="host"))
+    try:
+        yield builder
+    finally:
+        builder.remove()
+
+
 @retry_with_backoff()  # Uses config defaults
-def build_image(image_conf, image_tag, dockerfile_directory, dockerfile_path, debug):
-    print("> [Info] Building: " + image_tag[0])
+def build_image(image_conf, image_tag, dockerfile_directory, dockerfile_path, debug, builder, cache=False):
+    # image_tag is a single tag for the local build and a list for the remote
+    # registries; normalise so the log names every tag rather than, for a bare
+    # string, its first character.
+    tags = [image_tag] if isinstance(image_tag, str) else image_tag
+    print("> [Info] Building: " + ", ".join(tags))
     try:
         if debug:
             pp = pprint.PrettyPrinter(indent=1)
@@ -82,17 +104,12 @@ def build_image(image_conf, image_tag, dockerfile_directory, dockerfile_path, de
             print(dockerfile_path)
             print("\n")
 
-        # Create a buildx builder instance
-        builder = docker.buildx.create(
-            use=True, driver_options=dict(network="host"))
-
-        # Build and push to local registry
         docker.buildx.build(
             builder=builder,
             file=os.path.join(dockerfile_directory, dockerfile_path),
             context_path=dockerfile_directory,
-            tags=image_tag,
-            cache=False,
+            tags=tags,
+            cache=cache,
             push=True,
             build_args=image_conf["build_args"] if "build_args" in image_conf else {
             }, platforms=image_conf["platforms"]
@@ -101,8 +118,6 @@ def build_image(image_conf, image_tag, dockerfile_directory, dockerfile_path, de
     except DockerException as docker_exception:
         print("> [Error] Build error - " + str(docker_exception))
         raise
-    finally:
-        builder.remove()
 
     print("Build successful")
 


### PR DESCRIPTION
Follow-up to #2019, which halved the runs per pull request. This halves the work inside a *publishing* run.

## Problem

Every master merge, release and nightly builds each image **twice**. [`build()`](image_builder.py#L38-L70) builds to the throwaway local registry and runs the tests against it, then calls `build_image` again for Docker Hub and GHCR — a second build, from scratch, with `cache=False`, on a second builder.

Two consequences:

- publishing runs pay double the build time
- **the image that reaches the registries is not the one the tests exercised.** They are two independent builds of the same Dockerfile

## Change

The builder moves out of `build_image` into a context manager shared by both builds, and the publishing build takes the cache:

```python
with docker_tools.start_local_registry(), docker_tools.build_builder() as builder:
    docker_tools.build_image(..., builder)                 # cache=False, to localhost:5000
    docker_tools.run_image(...)                            # the tests run against that
    if publishing:
        login_to_registries(env_conf)
        docker_tools.build_image(..., builder, cache=True)  # every layer a cache hit
```

Every layer of the publishing build is a cache hit from the build the tests just ran against, so it exports those layers rather than producing new ones. The first build keeps `--no-cache` and still resolves everything fresh; the builder is created and destroyed inside the job, so its cache cannot outlive the run.

## Verification

Docker isn't available where this was written, so I drove the real `build()` with `python-on-whales` replaced by a stub and asserted on the calls it makes:

| scenario | builders | buildx builds |
|---|---|---|
| pull request | 1 created, 1 removed | 1, `cache=False` |
| push to master | 1 created, 1 removed *(was 2)* | 2, both on the **same** builder, second `cache=True` |

**The assumption this rests on**, which only a real run can confirm: that `--no-cache` on the first build still *populates* the builder's cache for the second. That is standard BuildKit behaviour — `--no-cache` means "do not read the cache", not "do not write it" — and it will show up as `CACHED` against the publishing build's steps in the first master log.

## Why not copy the manifest instead

#2019's description floated `docker buildx imagetools create(sources=[local], tags=[...])`, which would skip the second build entirely. I checked it before building on it and did not take it:

- `imagetools` has no `--insecure` flag and [a history of refusing plain-HTTP registries](https://github.com/docker/for-win/issues/13934). The local registry is plain HTTP. `127.0.0.0/8` is sometimes treated as an exception, and there is no Docker here to settle it either way.
- The failure modes are not comparable. If the cache assumption above is wrong, the second build simply rebuilds and we are back to today's behaviour — no saving, nothing broken. If `imagetools` cannot read the local registry, **master stops publishing images**.

Worth revisiting once someone can try `imagetools create` against the local registry on a runner; the saving would be the export/push time this PR still spends.

## Two incidental fixes, in the code being moved

- `build_image` logged `image_tag[0]`. For the local build that argument is a single string, so the log read `Building: l` — its first character. It now names every tag, which is what makes the `CACHED` check above legible.
- The old `finally: builder.remove()` would raise `NameError` if `buildx.create` itself failed, masking the real error. The context manager only removes a builder it created.

## What to watch on the first master run

The publishing build's steps should report `CACHED`, and the run should finish appreciably faster than the previous master build. If the steps rebuild instead, the change is inert rather than harmful — worth reverting or revisiting `imagetools` at that point.
