### PR TITLE
ci: cap build jobs so a wedged QEMU step cannot burn six hours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,13 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
+    # A QEMU-emulated arm64 step that dies of SIGILL does not fail the build, it
+    # wedges it: BuildKit never notices, and the job runs to GitHub's 6 hour
+    # ceiling. Two nightlies have burned 360 minutes that way. The slowest
+    # legitimate job is around 40 minutes, and was 80 before the publishing
+    # build started reusing the tested layers, so this leaves ample headroom
+    # while turning a wedge into a failure you can rerun.
+    timeout-minutes: 120
     # GITHUB_TOKEN is used to log in to ghcr.io and push, so keep it to the
     # minimum this job actually needs.
     permissions:


### PR DESCRIPTION
A one-line cap on the `build` job, because a crashed QEMU step currently hangs for six hours instead of failing.

## What happens today

`npm install` under QEMU-emulated arm64 dies of SIGILL often enough to matter, in the `reviewtools` image:

```
#17 [linux/arm64 5/8] RUN npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli
#17 22.94 qemu: uncaught target signal 4 (Illegal instruction) - core dumped
```

Every wedged `reviewtools` job I could find in recent history crashed at that same step, always `linux/arm64` — the `qemu:` prefix confirms emulation, since amd64 runs natively on the runner:

| job | step | signal | ran for |
|---|---|---|---|
| [100902422275](https://github.com/ekino/docker-buildbox/actions/runs/33833900365/job/100902422275) | `[linux/arm64 5/8] RUN npm install` | 4 (SIGILL) | 188 min |
| 100646900924 | `[linux/arm64 5/8] RUN npm install` | 4 (SIGILL) | 44 min |
| 100513491272 | `[linux/arm64 5/8] RUN npm install` | 4 (SIGILL) | **360 min** |
| 100199037272 | `[linux/arm64 5/8] RUN npm install` | 4 (SIGILL) | **360 min** |

**The crash does not fail the build — it wedges it.** BuildKit never notices its child died, so nothing reports an error: after the core dump the log is silent for hours, then cancellation cleanup. 360 minutes is GitHub's 6-hour job ceiling, so two nightlies ran until the platform stopped them.

## Change

```yaml
  build:
    runs-on: ubuntu-24.04
    timeout-minutes: 120
```

That is the whole change; the rest of the diff is the comment explaining why the number is what it is.

**Why 120.** The slowest legitimate job is ~40 minutes today (`php 8.4`, 38 min in the last master run) and was ~80 before #2020 made publishing builds reuse the tested layers. 120 sits well clear of both, so it cannot cause a false failure on a slow runner or a cache miss, while cutting a wedged job's cost by two thirds. It can be tightened to ~60 once a few nightlies confirm the post-#2020 durations.

`fail-fast: false` is already set on the matrix, so a job hitting the cap fails alone and the other 26 images still build and publish.

## What this does and does not do

It bounds the damage: a wedge becomes a red job you can rerun, in 2 hours rather than 6, and a nightly no longer looks stuck all day.

It does not fix the cause. QEMU's aarch64 emulation mishandles instructions V8's JIT emits, which is why it is intermittent — whether the optimising compiler reaches the bad sequence depends on timing. It is a [known failure mode](https://github.com/orgs/community/discussions/182217), and Node on Alpine under QEMU is one of its worst corners.

The real fix is to stop emulating: [arm64 hosted runners are generally available and free for public repositories](https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/), and building arm64 natively would remove this bug class entirely — and speed up every image, since emulated arm64 is the slowest part of every build. That is a restructure (a platform dimension on the matrix, single-arch builds per native runner, then a manifest merge), so it wants its own PR. Worth noting [`config.py:94`](src/config.py#L94) already computes per-arch tags that nothing currently uses, so the shape was anticipated.

Dropping `linux/arm64` from `reviewtools` alone is the other option, if nobody needs that image on arm64.
