### PR TITLE
fix(php): fail the build when a tool download fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions
 * AWS, Azure, GCP & Scaleway: Helm is no longer a release candidate. The 3.x lookup matched any tag containing v3.x.y, so a published v3.x.y-rc.N was picked ahead of the newest stable release
 * AWS, Chrome, DIND, Golang, Node, PHP & Scaleway: fixing the mime.types source, the Debian mime-support repository having been renamed to media-types. The old URL had been returning 404 for a while, and its HTML error page was being written to /etc/mime.types
 * Cloudsploit: removing this image, as we're now using Prowler instead. Existing `ekino/ci-cloudsploit` tags are left in place but will no longer be rebuilt or receive updates
+* PHP: the downloads of composer, php-cs-fixer, phpredis, xdebug and the Blackfire probe and client now fail the build, and retry on transient errors, instead of silently writing an HTTP error page to the target path. A GitHub 504 on the php-cs-fixer release asset was being saved as an executable `/usr/local/bin/php-cs-fixer` and only surfaced four minutes later as a test failure. php-cs-fixer is also fetched from the project's current repository name, PHP-CS-Fixer/PHP-CS-Fixer, rather than through the FriendsOfPHP redirect left over from the rename
 * Prowler: added new image with Prowler and AWS CLI v2
 
 2026-08-31

--- a/php/8.2/Dockerfile
+++ b/php/8.2/Dockerfile
@@ -38,26 +38,26 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") && \
     date.timezone=${PHP_TIMEZONE:-UTC} \n\
     short_open_tag=Off \n\
     " > /usr/local/etc/php/php.ini && \
-    curl -sSL https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -o /usr/local/bin/composer && chmod a+x /usr/local/bin/composer && \
-    curl -sSL https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v${PHP_CS_FIXER_VERSION}/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer && chmod a+x /usr/local/bin/php-cs-fixer && \
-    curl -sSL https://github.com/phpredis/phpredis/archive/${REDIS_VERSION}.tar.gz | tar xz -C /tmp && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -o /usr/local/bin/composer && chmod a+x /usr/local/bin/composer && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v${PHP_CS_FIXER_VERSION}/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer && chmod a+x /usr/local/bin/php-cs-fixer && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/phpredis/phpredis/archive/${REDIS_VERSION}.tar.gz | tar xz -C /tmp && \
     cd /tmp/phpredis-${REDIS_VERSION} && phpize && ./configure && make && make install && \
     echo "extension=redis.so" > /usr/local/etc/php/conf.d/redis.ini && \
-    curl -sSL https://github.com/xdebug/xdebug/archive/${XDEBUG_VERSION}.tar.gz | tar xz -C /tmp && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/xdebug/xdebug/archive/${XDEBUG_VERSION}.tar.gz | tar xz -C /tmp && \
     cd /tmp/xdebug-${XDEBUG_VERSION} && phpize && ./configure --enable-xdebug && make && make install && \
     echo -e "zend_extension=xdebug.so \nxdebug.mode=coverage \n" > /usr/local/etc/php/conf.d/xdebug.ini && \
     mkdir -p /tmp/blackfire-probe && \
-    curl -A "Docker" -o /tmp/blackfire-probe/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/${TARGETARCH}/$version && \
+    curl -f -A "Docker" --retry 5 --retry-delay 2 --retry-all-errors -o /tmp/blackfire-probe/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/${TARGETARCH}/$version && \
     tar zxpf /tmp/blackfire-probe/blackfire-probe.tar.gz -C /tmp/blackfire-probe && \
     mv /tmp/blackfire-probe/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so && \
     printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini && \
     mkdir -p /tmp/blackfire-client && \
-    curl -A "Docker" -L https://blackfire.io/api/v1/releases/cli/linux/${TARGETARCH} | tar zxp -C /tmp/blackfire-client && \
+    curl -f -A "Docker" --retry 5 --retry-delay 2 --retry-all-errors -L https://blackfire.io/api/v1/releases/cli/linux/${TARGETARCH} | tar zxp -C /tmp/blackfire-client && \
     mv /tmp/blackfire-client/blackfire /usr/bin/blackfire && \
     # Starting AWS
     apk add aws-cli && \
     # Adding an up to date mime-types definition file
-    curl -fsSL --retry 3 --retry-delay 2 https://salsa.debian.org/debian/media-types/raw/master/mime.types -o /etc/mime.types && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://salsa.debian.org/debian/media-types/raw/master/mime.types -o /etc/mime.types && \
     # Cleaning files
     apk del --purge alpine-sdk autoconf && \
     rm -rf /tmp/* /usr/share/doc /var/cache/apk/*

--- a/php/8.3/Dockerfile
+++ b/php/8.3/Dockerfile
@@ -37,26 +37,26 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") && \
     date.timezone=${PHP_TIMEZONE:-UTC} \n\
     short_open_tag=Off \n\
     " > /usr/local/etc/php/php.ini && \
-    curl -sSL https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -o /usr/local/bin/composer && chmod a+x /usr/local/bin/composer && \
-    curl -sSL https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v${PHP_CS_FIXER_VERSION}/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer && chmod a+x /usr/local/bin/php-cs-fixer && \
-    curl -sSL https://github.com/phpredis/phpredis/archive/${REDIS_VERSION}.tar.gz | tar xz -C /tmp && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -o /usr/local/bin/composer && chmod a+x /usr/local/bin/composer && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v${PHP_CS_FIXER_VERSION}/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer && chmod a+x /usr/local/bin/php-cs-fixer && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/phpredis/phpredis/archive/${REDIS_VERSION}.tar.gz | tar xz -C /tmp && \
     cd /tmp/phpredis-${REDIS_VERSION} && phpize && ./configure && make && make install && \
     echo "extension=redis.so" > /usr/local/etc/php/conf.d/redis.ini && \
-    curl -sSL https://github.com/xdebug/xdebug/archive/${XDEBUG_VERSION}.tar.gz | tar xz -C /tmp && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/xdebug/xdebug/archive/${XDEBUG_VERSION}.tar.gz | tar xz -C /tmp && \
     cd /tmp/xdebug-${XDEBUG_VERSION} && phpize && ./configure --enable-xdebug && make && make install && \
     echo -e "zend_extension=xdebug.so \nxdebug.mode=coverage \n" > /usr/local/etc/php/conf.d/xdebug.ini && \
     mkdir -p /tmp/blackfire-probe && \
-    curl -A "Docker" -o /tmp/blackfire-probe/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/${TARGETARCH}/$version && \
+    curl -f -A "Docker" --retry 5 --retry-delay 2 --retry-all-errors -o /tmp/blackfire-probe/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/${TARGETARCH}/$version && \
     tar zxpf /tmp/blackfire-probe/blackfire-probe.tar.gz -C /tmp/blackfire-probe && \
     mv /tmp/blackfire-probe/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so && \
     printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini && \
     mkdir -p /tmp/blackfire-client && \
-    curl -A "Docker" -L https://blackfire.io/api/v1/releases/cli/linux/${TARGETARCH} | tar zxp -C /tmp/blackfire-client && \
+    curl -f -A "Docker" --retry 5 --retry-delay 2 --retry-all-errors -L https://blackfire.io/api/v1/releases/cli/linux/${TARGETARCH} | tar zxp -C /tmp/blackfire-client && \
     mv /tmp/blackfire-client/blackfire /usr/bin/blackfire && \
     # Starting AWS
     apk add aws-cli && \
     # Adding an up to date mime-types definition file
-    curl -fsSL --retry 3 --retry-delay 2 https://salsa.debian.org/debian/media-types/raw/master/mime.types -o /etc/mime.types && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://salsa.debian.org/debian/media-types/raw/master/mime.types -o /etc/mime.types && \
     # Cleaning files
     apk del --purge alpine-sdk autoconf && \
     rm -rf /tmp/* /usr/share/doc /var/cache/apk/*

--- a/php/8.4/Dockerfile
+++ b/php/8.4/Dockerfile
@@ -37,26 +37,26 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") && \
     date.timezone=${PHP_TIMEZONE:-UTC} \n\
     short_open_tag=Off \n\
     " > /usr/local/etc/php/php.ini && \
-    curl -sSL https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -o /usr/local/bin/composer && chmod a+x /usr/local/bin/composer && \
-    curl -sSL https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v${PHP_CS_FIXER_VERSION}/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer && chmod a+x /usr/local/bin/php-cs-fixer && \
-    curl -sSL https://github.com/phpredis/phpredis/archive/${REDIS_VERSION}.tar.gz | tar xz -C /tmp && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -o /usr/local/bin/composer && chmod a+x /usr/local/bin/composer && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v${PHP_CS_FIXER_VERSION}/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer && chmod a+x /usr/local/bin/php-cs-fixer && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/phpredis/phpredis/archive/${REDIS_VERSION}.tar.gz | tar xz -C /tmp && \
     cd /tmp/phpredis-${REDIS_VERSION} && phpize && ./configure && make && make install && \
     echo "extension=redis.so" > /usr/local/etc/php/conf.d/redis.ini && \
-    curl -sSL https://github.com/xdebug/xdebug/archive/${XDEBUG_VERSION}.tar.gz | tar xz -C /tmp && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/xdebug/xdebug/archive/${XDEBUG_VERSION}.tar.gz | tar xz -C /tmp && \
     cd /tmp/xdebug-${XDEBUG_VERSION} && phpize && ./configure --enable-xdebug && make && make install && \
     echo -e "zend_extension=xdebug.so \nxdebug.mode=coverage \n" > /usr/local/etc/php/conf.d/xdebug.ini && \
     mkdir -p /tmp/blackfire-probe && \
-    curl -A "Docker" -o /tmp/blackfire-probe/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/${TARGETARCH}/$version && \
+    curl -f -A "Docker" --retry 5 --retry-delay 2 --retry-all-errors -o /tmp/blackfire-probe/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/${TARGETARCH}/$version && \
     tar zxpf /tmp/blackfire-probe/blackfire-probe.tar.gz -C /tmp/blackfire-probe && \
     mv /tmp/blackfire-probe/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so && \
     printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini && \
     mkdir -p /tmp/blackfire-client && \
-    curl -A "Docker" -L https://blackfire.io/api/v1/releases/cli/linux/${TARGETARCH} | tar zxp -C /tmp/blackfire-client && \
+    curl -f -A "Docker" --retry 5 --retry-delay 2 --retry-all-errors -L https://blackfire.io/api/v1/releases/cli/linux/${TARGETARCH} | tar zxp -C /tmp/blackfire-client && \
     mv /tmp/blackfire-client/blackfire /usr/bin/blackfire && \
     # Starting AWS
     apk add aws-cli && \
     # Adding an up to date mime-types definition file
-    curl -fsSL --retry 3 --retry-delay 2 https://salsa.debian.org/debian/media-types/raw/master/mime.types -o /etc/mime.types && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://salsa.debian.org/debian/media-types/raw/master/mime.types -o /etc/mime.types && \
     # Cleaning files
     apk del --purge alpine-sdk autoconf && \
     rm -rf /tmp/* /usr/share/doc /var/cache/apk/*

--- a/php/8.5/Dockerfile
+++ b/php/8.5/Dockerfile
@@ -37,26 +37,26 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") && \
     date.timezone=${PHP_TIMEZONE:-UTC} \n\
     short_open_tag=Off \n\
     " > /usr/local/etc/php/php.ini && \
-    curl -sSL https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -o /usr/local/bin/composer && chmod a+x /usr/local/bin/composer && \
-    curl -sSL https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v${PHP_CS_FIXER_VERSION}/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer && chmod a+x /usr/local/bin/php-cs-fixer && \
-    curl -sSL https://github.com/phpredis/phpredis/archive/${REDIS_VERSION}.tar.gz | tar xz -C /tmp && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -o /usr/local/bin/composer && chmod a+x /usr/local/bin/composer && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v${PHP_CS_FIXER_VERSION}/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer && chmod a+x /usr/local/bin/php-cs-fixer && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/phpredis/phpredis/archive/${REDIS_VERSION}.tar.gz | tar xz -C /tmp && \
     cd /tmp/phpredis-${REDIS_VERSION} && phpize && ./configure && make && make install && \
     echo "extension=redis.so" > /usr/local/etc/php/conf.d/redis.ini && \
-    curl -sSL https://github.com/xdebug/xdebug/archive/${XDEBUG_VERSION}.tar.gz | tar xz -C /tmp && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://github.com/xdebug/xdebug/archive/${XDEBUG_VERSION}.tar.gz | tar xz -C /tmp && \
     cd /tmp/xdebug-${XDEBUG_VERSION} && phpize && ./configure --enable-xdebug && make && make install && \
     echo -e "zend_extension=xdebug.so \nxdebug.mode=coverage \n" > /usr/local/etc/php/conf.d/xdebug.ini && \
     mkdir -p /tmp/blackfire-probe && \
-    curl -A "Docker" -o /tmp/blackfire-probe/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/${TARGETARCH}/$version && \
+    curl -f -A "Docker" --retry 5 --retry-delay 2 --retry-all-errors -o /tmp/blackfire-probe/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/${TARGETARCH}/$version && \
     tar zxpf /tmp/blackfire-probe/blackfire-probe.tar.gz -C /tmp/blackfire-probe && \
     mv /tmp/blackfire-probe/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so && \
     printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini && \
     mkdir -p /tmp/blackfire-client && \
-    curl -A "Docker" -L https://blackfire.io/api/v1/releases/cli/linux/${TARGETARCH} | tar zxp -C /tmp/blackfire-client && \
+    curl -f -A "Docker" --retry 5 --retry-delay 2 --retry-all-errors -L https://blackfire.io/api/v1/releases/cli/linux/${TARGETARCH} | tar zxp -C /tmp/blackfire-client && \
     mv /tmp/blackfire-client/blackfire /usr/bin/blackfire && \
     # Starting AWS
     apk add aws-cli && \
     # Adding an up to date mime-types definition file
-    curl -fsSL --retry 3 --retry-delay 2 https://salsa.debian.org/debian/media-types/raw/master/mime.types -o /etc/mime.types && \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors https://salsa.debian.org/debian/media-types/raw/master/mime.types -o /etc/mime.types && \
     # Cleaning files
     apk del --purge alpine-sdk autoconf && \
     rm -rf /tmp/* /usr/share/doc /var/cache/apk/*


### PR DESCRIPTION
## Why

[`build php 8.3 (amd64)` and `build php 8.5 (amd64)`](https://github.com/ekino/docker-buildbox/actions/runs/34130153728) failed on master today, taking their two `merge` jobs with them. The test `php-cs-fixer --version` exited 2 with:

```
/usr/local/bin/php-cs-fixer: line 1: syntax error: unexpected redirection
```

That is the shell parsing `<html>` as a redirection. `curl -sSL` without `-f` writes the HTTP error body to the target path and exits 0, so a transient GitHub 504 on the php-cs-fixer release asset was saved as an executable `/usr/local/bin/php-cs-fixer`, `chmod a+x`'d, and the build reported success. The failure only surfaced four minutes later, at test time, in a job that had already spent its build budget.

The pinned version is not the problem: `build php 8.2 (amd64)` downloaded and ran php-cs-fixer 3.95.11 successfully in the same run, uncached. The 504 is flaky per request, which is why some php jobs failed and others did not.

## What

- Add `-f --retry 5 --retry-delay 2 --retry-all-errors` to every download in the php `RUN` layer - composer, php-cs-fixer, phpredis, xdebug and both Blackfire fetches - across 8.2, 8.3, 8.4 and 8.5. `-f` is the fix; the retries ride out the transient failures that made this a build error at all. The `mime.types` line was already `-f`, and its retry flags are harmonised so the layer reads as one style.
- Fetch php-cs-fixer from `PHP-CS-Fixer/PHP-CS-Fixer` rather than through the `FriendsOfPHP` redirect left over from the repository rename.

## Verification

- `uv run python image_builder.py build --image php --version 8.3` - build successful, tests successful (arm64), so `php-cs-fixer --version` works through the new URL.
- Fail-fast confirmed in the base image: `curl -fsSL --retry 2 --retry-all-errors <the v3.95.11 phar>` makes three attempts, exits 22 and **writes no file**, where the old flags left the 504 body at `/usr/local/bin/php-cs-fixer`.

## Not addressed

The three piped downloads (`curl ... | tar xz`) still take their exit status from `tar` rather than curl, there being no `pipefail`. `tar` rejects an HTML body anyway, so the chain aborts - one step later than `-f` would. `SHELL ["/bin/sh", "-o", "pipefail", "-c"]` would tighten it if wanted.