### PR TITLE
feat(reviewtools): add chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versions
 * Cloudsploit: removing this image, as we're now using Prowler instead. Existing `ekino/ci-cloudsploit` tags are left in place but will no longer be rebuilt or receive updates
 * PHP: the downloads of composer, php-cs-fixer, phpredis, xdebug and the Blackfire probe and client now fail the build, and retry on transient errors, instead of silently writing an HTTP error page to the target path. A GitHub 504 on the php-cs-fixer release asset was being saved as an executable `/usr/local/bin/php-cs-fixer` and only surfaced four minutes later as a test failure. php-cs-fixer is also fetched from the project's current repository name, PHP-CS-Fixer/PHP-CS-Fixer, rather than through the FriendsOfPHP redirect left over from the rename
 * Prowler: added new image with Prowler and AWS CLI v2
+* Reviewtools: adding chromium, so the review tools can drive a browser through puppeteer or playwright. Both are pointed at the Alpine build via `PUPPETEER_EXECUTABLE_PATH` and `CHROME_PATH`, and told not to download their own
 
 2026-08-31
 ----------

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Contains Chromium browser and the latest Node LTS.
 - https://hub.docker.com/r/ekino/ci-reviewtools/tags
 - https://github.com/orgs/ekino/packages/container/package/ci-reviewtools
 
-Contains Node.js 24 on Alpine Linux with AI code review tools: Claude Code, OpenAI Codex, and Google Gemini CLI. Runs under a dedicated `reviewtools:reviewtools` user for security.
+Contains Node.js 24 on Alpine Linux with AI code review tools: Claude Code, OpenAI Codex, and Google Gemini CLI, plus Chromium for browser automation. Runs under a dedicated `reviewtools:reviewtools` user for security.
 
 ### GCP
 - https://hub.docker.com/r/ekino/ci-gcp/tags

--- a/reviewtools/Dockerfile
+++ b/reviewtools/Dockerfile
@@ -2,7 +2,16 @@ FROM node:24-alpine3.24
 LABEL maintainer="opensource@ekino.com"
 LABEL org.opencontainers.image.source="https://github.com/ekino/docker-buildbox/"
 
-RUN apk update && apk add --no-cache git curl bash jq python3 make g++ coreutils
+RUN apk update && apk add --no-cache git curl bash jq python3 make g++ coreutils \
+    chromium nss freetype harfbuzz ttf-freefont
+
+# Browser automation tools (puppeteer, playwright) must use the Chromium from
+# apk: the versions they download themselves are glibc builds and don't run on
+# Alpine.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true \
+    CHROME_PATH=/usr/bin/chromium-browser
 
 # Install GitLab CLI (glab)
 ARG TARGETARCH

--- a/reviewtools/config.yml
+++ b/reviewtools/config.yml
@@ -6,6 +6,7 @@ test_config: &test_config
     - codex --version
     - gemini --version
     - glab --version
+    - chromium-browser --no-sandbox --version
 
 versions:
   '1':


### PR DESCRIPTION
Adds Chromium to the reviewtools image so the AI review tools can drive a browser through puppeteer or playwright. Both are pointed at the apk build via `PUPPETEER_EXECUTABLE_PATH`/`CHROME_PATH` and told not to download their own, since those glibc binaries don't run on Alpine.